### PR TITLE
Fix for gutentags#statusline() with no args.

### DIFF
--- a/plugin/gutentags.vim
+++ b/plugin/gutentags.vim
@@ -469,7 +469,7 @@ function! gutentags#statusline(...) abort
 
     " Figure out what the user is customizing.
     let l:gen_msg = 'TAGS'
-    if a:0 >= 0
+    if a:0 > 0
         let l:gen_msg = a:1
     endif
 


### PR DESCRIPTION
If I add `set statusline+=%{gutentags#statusline()}` to my vimrc, as suggested by the help document, I see the following error when I edit a file under my working directory:

```
Error detected while processing function gutentags#statusline:
line    9:
E121: Undefined variable: a:1
```

The reason for this is the statusline() function tests that a:0 >= 0 instead of > 0 before accessing a:1. If the argument count is 0, then a:1 is undefined, of course.
