### PR TITLE
Prevent lock and temp-File to remain after forced exit.

### DIFF
--- a/plat/unix/update_tags.sh
+++ b/plat/unix/update_tags.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -64,6 +64,9 @@ fi
 
 echo "Locking tags file..."
 echo $$ > "$TAGS_FILE.lock"
+
+# Remove lock and temp file if script is stopped unexpectedly.
+trap "rm -f \"$TAGS_FILE.lock\" \"$TAGS_FILE.temp\"" 0 3 4 15
 
 if [[ -f "$TAGS_FILE" ]]; then
     if [[ "$UPDATED_SOURCE" != "" ]]; then


### PR DESCRIPTION
Added trap to remove those temporary files if the script gets stopped
unexpectedly (e.g. when vim is exited before the tag-file is fully
generated.)

Also changed /bin/sh to /bin/bash, because [[ ]] doesn't work with an
standard shell. You need at least bash.
