### PR TITLE
Cscope support for Unix systems

### DIFF
--- a/plat/unix/update_scopedb.sh
+++ b/plat/unix/update_scopedb.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+set -e
+
+PROG_NAME=$0
+CSCOPE_EXE=cscope
+DB_FILE=cscope.out
+PROJECT_ROOT=
+
+ShowUsage() {
+    echo "Usage:"
+    echo "    $PROG_NAME <options>"
+    echo ""
+    echo "    -e [exe=cscope]:      The cscope executable to run"
+    echo "    -f [file=cscope.out]: The path to the ctags file to update"
+    echo "    -p [dir=]:            The path to the project root"
+    echo ""
+}
+
+
+while getopts "h?e:f:p:" opt; do
+    case $opt in
+        h|\?)
+            ShowUsage
+            exit 0
+            ;;
+        e)
+            CSCOPE_EXE=$OPTARG
+            ;;
+        f)
+            DB_FILE=$OPTARG
+            ;;
+        p)
+            PROJECT_ROOT=$OPTARG
+            ;;
+    esac
+done
+
+shift $((OPTIND - 1))
+
+if [ "$1" != "" ]; then
+    echo "Invalid Argument: $1"
+    exit 1
+fi
+
+echo "Locking cscope DB file..."
+echo $$ > "$DB_FILE.lock"
+
+# Remove lock and temp file if script is stopped unexpectedly.
+trap "rm -f \"$DB_FILE.lock\" \"$DB_FILE.temp\"" 0 3 4 15
+
+PREVIOUS_DIR=$(pwd)
+if [ -d "$PROJECT_ROOT" ]; then
+    cd "$PROJECT_ROOT"
+fi
+
+echo "Running cscope"
+echo "$CSCOPE_EXE -R -b -k -f \"$DB_FILE.temp\""
+"$CSCOPE_EXE" -R -v -b -k -f "$DB_FILE.temp"
+
+if [ -d "$PROJECT_ROOT" ]; then
+    cd "$PREVIOUS_DIR"
+fi
+
+echo "Replacing cscope DB file"
+echo "mv -f \"$DB_FILE.temp\" \"$DB_FILE\""
+mv -f "$DB_FILE.temp" "$DB_FILE"
+
+echo "Unlocking cscope DB file..."
+rm -f "$DB_FILE.lock"
+
+echo "Done."

--- a/plat/win32/update_scopedb.cmd
+++ b/plat/win32/update_scopedb.cmd
@@ -6,7 +6,7 @@ rem            PARSE ARGUMENTS
 rem ==========================================
 
 set CSCOPE_EXE=cscope
-set DB_FILE=scope.out
+set DB_FILE=cscope.out
 
 :ParseArgs
 if [%1]==[] goto :DoneParseArgs
@@ -43,7 +43,7 @@ echo Locking db file
 echo locked > "%DB_FILE%.lock"
 
 echo Running cscope
-cscope -R -b -k -f "%DB_FILE%"
+"%CSCOPE_EXE%" -R -b -k -f "%DB_FILE%"
 if ERRORLEVEL 1 (
     echo ERROR: Cscope executable returned non-zero code.
 )


### PR DESCRIPTION
I saw recently you added cscope support and gave it a try today.

But I believe there a few problems : 
 * cscope database are the most useful in the top directory of the project, but as far as I know you need to be in this directory to generate the DB (so I added this part in the unix script but I'm not sure how to do it for Windows sorry :( )
 * once the DB has been updated you have to use ```cs reset``` in vim in order to synchronize with the changes (the change for 'neovim' support is here to fix this issue)
 * one issue I did not address in this PR, is the fact that the "intial" generation of the database can be quite long (for example in on of my projects it needs about 1/2 minutes) but if you change a few files and re-run the cscope generation with the old data it may only take a few seconds, quite simply that would mean not using a 'temporary file', maybe with the exception of neovim as you can run job asynchronously.

I only made the change for neovim new function ```jobstart``` in the cscope file as I'm not sure it's needed in the ctags part.

Moreover this pull request is more a diff were you pick what you want or think is useful.


 * on a side note, once these items are solved it would be great to add a few words / lines how to add cscope support for ```vim-gutentags```

