### PR TITLE
Fix dysfunctional checking for ctags command variable

### DIFF
--- a/autoload/gutentags/ctags.vim
+++ b/autoload/gutentags/ctags.vim
@@ -2,7 +2,7 @@
 
 " Global Options {{{
 
-if !exists('g:gutentags_ctags_executable')
+if !exists('g:gutentags_executable')
     let g:gutentags_executable = 'ctags'
 endif
 

--- a/doc/gutentags.txt
+++ b/doc/gutentags.txt
@@ -218,8 +218,8 @@ g:gutentags_enabled
                         don't.
                         Defaults to 1.
 
-                                                *gutentags_ctags_executable*
-g:gutentags_ctags_executable
+                                                *gutentags_executable*
+g:gutentags_executable
                         Specifies the ctags executable to launch.
                         Defaults to `ctags`.
 


### PR DESCRIPTION
It was checking for the existence of a variable `gutentags_ctags_executable`, while the one that was being assigned and used was `gutentags_executable`. This last name is now used everywhere (also changed in the docs).