### PR TITLE
Add the feature to configure ctags executables specific for filetypes

### DIFF
--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -177,8 +177,10 @@ endfunction
 
 " Get final ctags executable depending whether a filetype one is defined
 function! gutentags#get_ctags_executable() abort
-  if exists('g:gutentags_ctags_executable_{&filetype}')
-    return g:gutentags_ctags_executable_{&filetype}
+  "Only consider the main filetype in cases like 'python.django'
+  let l:ftype = get(split(&filetype, '\.'), 0, '')
+  if exists('g:gutentags_ctags_executable_{l:ftype}')
+    return g:gutentags_ctags_executable_{l:ftype}
   else
     return g:gutentags_ctags_executable
   endif

--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -175,6 +175,15 @@ function! gutentags#get_execute_cmd() abort
     endif
 endfunction
 
+" Get final ctags executable depending whether a filetype one is defined
+function! gutentags#get_ctags_executable() abort
+  if exists('g:gutentags_ctags_executable_{&filetype}')
+    return g:gutentags_ctags_executable_{&filetype}
+  else
+    return g:gutentags_ctags_executable
+  endif
+endfunction
+
 " Get the suffix for how to execute an external command.
 function! gutentags#get_execute_cmd_suffix() abort
     if has('win32')

--- a/autoload/gutentags/ctags.vim
+++ b/autoload/gutentags/ctags.vim
@@ -41,7 +41,7 @@ function! gutentags#ctags#generate(proj_dir, tags_file, write_mode) abort
     try
         " Build the command line.
         let l:cmd = gutentags#get_execute_cmd() . s:runner_exe
-        let l:cmd .= ' -e "' . g:gutentags_ctags_executable . '"'
+        let l:cmd .= ' -e "' . gutentags#get_ctags_executable() . '"'
         let l:cmd .= ' -t "' . a:tags_file . '"'
         let l:cmd .= ' -p "' . a:proj_dir . '"'
         if a:write_mode == 0 && filereadable(a:tags_file)

--- a/doc/gutentags.txt
+++ b/doc/gutentags.txt
@@ -223,6 +223,15 @@ g:gutentags_ctags_executable
                         Specifies the ctags executable to launch.
                         Defaults to `ctags`.
 
+                                     *gutentags_ctags_executable_{filetype}*
+g:gutentags_ctags_executable_{filetype}
+                        Specifies the ctags executable to launch for
+                        {filetype} files. It has precedence over
+                        g:gutentags_ctags_executable.
+                        Example: >
+                         let g:gutentags_ctags_executable_ruby = 'ripper-tags'
+<
+
                                                 *gutentags_tagfile*
 g:gutentags_tagfile
                         Specifies the name of the tag file to create. This


### PR DESCRIPTION
If, for example, a variable `g:gutentags_ctags_executable_ruby` is found, its value will be used as the ctags executable command for ruby filetype files. Otherwise, it will default to global `g:gutentags_ctags_executable`

My need is to be able to use [ripper-tags](https://github.com/tmm1/ripper-tags) for ruby projects.

Please, if you need some code style or organizational modification feel free to tell me.