### PR TITLE
Without an exit in the trap, the remainig commands still get executed.

### DIFF
--- a/plat/unix/update_tags.sh
+++ b/plat/unix/update_tags.sh
@@ -67,7 +67,7 @@ echo "Locking tags file..."
 echo $$ > "$TAGS_FILE.lock"
 
 # Remove lock and temp file if script is stopped unexpectedly.
-trap "rm -f \"$TAGS_FILE.lock\" \"$TAGS_FILE.temp\"" 0 3 4 15
+trap "errorcode=$?; rm -f \"$TAGS_FILE.lock\" \"$TAGS_FILE.temp\"; exit $errorcode" INT TERM EXIT
 
 if [ -f "$TAGS_FILE" ]; then
     if [ "$UPDATED_SOURCE" != "" ]; then


### PR DESCRIPTION
I pushed something wrong last time I created the fix for the removing of the tags.-Files. I forgot an exit, so the script didn't really stop and the files could remain nevertheless.