### PR TITLE
Use full list of root markers in get_project_root.

### DIFF
--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -67,7 +67,7 @@ function! gutentags#get_project_root(path) abort
         let l:markers += g:ctrlp_root_markers
     endif
     while l:path != l:previous_path
-        for root in g:gutentags_project_root
+        for root in l:markers
             if getftype(l:path . '/' . root) != ""
                 let l:proj_dir = simplify(fnamemodify(l:path, ':p'))
                 return gutentags#stripslash(l:proj_dir)


### PR DESCRIPTION
Use l:markers instead of g:gutentags_project_root as the source of
project root indicators when testing parent directories.

In get_project_root, the list l:markers is built up with the contents of
g:gutentags_project_root and g:ctrlp_root_markers (if it exists).
However, g:gutentags_project_root was used directly while testing for
the presence of project root indicators (l:markers was ignored).
```
diff --git a/autoload/gutentags.vim b/autoload/gutentags.vim
index 5029075..c9aac1b 100644
--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -67,7 +67,7 @@ function! gutentags#get_project_root(path) abort
         let l:markers += g:ctrlp_root_markers
     endif
     while l:path != l:previous_path
-        for root in g:gutentags_project_root
+        for root in l:markers
             if getftype(l:path . '/' . root) != ""
                 let l:proj_dir = simplify(fnamemodify(l:path, ':p'))
                 return gutentags#stripslash(l:proj_dir)
```