### PR TITLE
Resolve symlink when checking for project root

### DIFF
--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -110,7 +110,7 @@ function! gutentags#setup_gutentags() abort
     " Try and find what tags file we should manage.
     call gutentags#trace("Scanning buffer '" . bufname('%') . "' for gutentags setup...")
     try
-        let b:gutentags_root = gutentags#get_project_root(expand('%:p:h', 1))
+        let b:gutentags_root = gutentags#get_project_root(fnamemodify(resolve(expand('%:p', 1)), ':p:h'))
         if filereadable(b:gutentags_root . '/.notags')
             call gutentags#trace("'notags' file found... no gutentags support.")
             return


### PR DESCRIPTION
This is pretty useful for me since I clone my dot files repository in a folder and then symlink it to my home directory. This allows gutentags to find the project root in this specific cases.