### PR TITLE
Make pattern for removal of existing lines more specific

### DIFF
--- a/plat/unix/update_tags.sh
+++ b/plat/unix/update_tags.sh
@@ -74,7 +74,7 @@ if [ -f "$TAGS_FILE" ]; then
     if [ "$UPDATED_SOURCE" != "" ]; then
         echo "Removing references to: $UPDATED_SOURCE"
         tab="	"
-        cmd="grep -Ev '^[^$tab]+$tab$UPDATED_SOURCE$tab' '$TAGS_FILE' > '$TAGS_FILE.temp'"
+        cmd="grep --text -Ev '^[^$tab]+$tab$UPDATED_SOURCE$tab' '$TAGS_FILE' > '$TAGS_FILE.temp'"
         echo "$cmd"
         eval "$cmd" || true
         INDEX_WHOLE_PROJECT=0

--- a/plat/unix/update_tags.sh
+++ b/plat/unix/update_tags.sh
@@ -73,8 +73,10 @@ INDEX_WHOLE_PROJECT=1
 if [ -f "$TAGS_FILE" ]; then
     if [ "$UPDATED_SOURCE" != "" ]; then
         echo "Removing references to: $UPDATED_SOURCE"
-        echo "grep -v \"$UPDATED_SOURCE\" \"$TAGS_FILE\" > \"$TAGS_FILE.temp\""
-        grep -v "$UPDATED_SOURCE" "$TAGS_FILE" > "$TAGS_FILE.temp"
+        tab="	"
+        cmd="grep -Ev '^[^$tab]+$tab$UPDATED_SOURCE$tab' '$TAGS_FILE' > '$TAGS_FILE.temp'"
+        echo "$cmd"
+        eval "$cmd" || true
         INDEX_WHOLE_PROJECT=0
     fi
 fi


### PR DESCRIPTION
Explicitly match the file name in the second tab-delimited column.

Also, add a "|| true" to handle the case where no lines would be
selected by grep (e.g. after `touch tags` and only updating a single
file).

TODO:

 - [ ] do this for `plat/win32/update_tags.cmd`, too?!
    I don't know how `findstr /V /C:"%UPDATED_SOURCE%" "%TAGS_FILE%" > "%TAGS_FILE%.temp"`` would need to be modified though.