### PR TITLE
Be more specific when updating the source (awk edition)

### DIFF
--- a/plat/unix/update_tags.sh
+++ b/plat/unix/update_tags.sh
@@ -73,8 +73,9 @@ INDEX_WHOLE_PROJECT=1
 if [ -f "$TAGS_FILE" ]; then
     if [ "$UPDATED_SOURCE" != "" ]; then
         echo "Removing references to: $UPDATED_SOURCE"
-        echo "grep -v \"$UPDATED_SOURCE\" \"$TAGS_FILE\" > \"$TAGS_FILE.temp\""
-        grep -v "$UPDATED_SOURCE" "$TAGS_FILE" > "$TAGS_FILE.temp"
+        cmd="awk '\$2 != \"$UPDATED_SOURCE\"' '$TAGS_FILE' > '$TAGS_FILE.temp'"
+        echo "$cmd"
+        eval "$cmd"
         INDEX_WHOLE_PROJECT=0
     fi
 fi


### PR DESCRIPTION
Use `awk` to really match the filename only (second column).

This is an alternative (more simple) approach to
https://github.com/ludovicchabant/vim-gutentags/pull/72, but requires
`awk` instead of `grep`.

Performance is worse with this however (100 iterations on a ~30MB tags
file):

>   8.25s user 3.06s system 92% cpu 12.260 total

With #72:

>   2.70s user 2.76s system 69% cpu 7.890 total

So I suggest to close this PR, but wanted to bring it up consideration, because I had done it already.