### PR TITLE
Do not append defaults to g:gutentags_project_root

### DIFF
--- a/doc/gutentags.txt
+++ b/doc/gutentags.txt
@@ -238,10 +238,8 @@ g:gutentags_project_root
                         Gutentags will be enabled for the project, and a tags
                         file named after |gutentags_tagfile| will be created at
                         the project root.
-                        Defaults to `[]` (an empty |List|).
-                        A list of default markers will always be appended to
-                        the user-defined ones: ['.git', '.hg', '.bzr',
-                        '_darcs'].
+                        Defaults to `['.git', '.hg', '.svn', '.bzr', '_darcs',
+                        '_FOSSIL_', '.fslckout']`.
 
                                                 *gutentags_exclude*
 g:gutentags_exclude

--- a/plugin/gutentags.vim
+++ b/plugin/gutentags.vim
@@ -50,9 +50,8 @@ if !exists('g:gutentags_modules')
 endif
 
 if !exists('g:gutentags_project_root')
-    let g:gutentags_project_root = []
+    let g:gutentags_project_root = ['.git', '.hg', '.svn', '.bzr', '_darcs', '_FOSSIL_', '.fslckout']
 endif
-let g:gutentags_project_root += ['.git', '.hg', '.svn', '.bzr', '_darcs', '_FOSSIL_', '.fslckout']
 
 if !exists('g:gutentags_project_info')
     let g:gutentags_project_info = []


### PR DESCRIPTION
This will only cause unnecessary disk accesses when you want to use e.g.
only `.git` anyway.