### PR TITLE
WIP: use output files from modules as markers first

### DIFF
--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -82,12 +82,13 @@ endfunction
 " file path.
 function! gutentags#get_project_root(path) abort
     " Look for existing output files (tags, cscope.out etc) first.
+    let l:path_arg = gutentags#stripslash(a:path)
     if g:gutentags_use_generated_file_marker
         let l:markers = []
         for module in g:gutentags_modules
             exec 'let l:markers += [gutentags#'.module.'#filename()]'
         endfor
-        let l:path = gutentags#stripslash(a:path)
+        let l:path = l:path_arg
         let l:previous_path = ""
         while l:path != l:previous_path
             for root in l:markers
@@ -110,6 +111,8 @@ function! gutentags#get_project_root(path) abort
     if exists('g:ctrlp_root_markers')
         let l:markers += g:ctrlp_root_markers
     endif
+    let l:path = l:path_arg
+    let l:previous_path = ""
     while l:path != l:previous_path
         for root in l:markers
             if getftype(l:path . '/' . root) != ""

--- a/autoload/gutentags/cscope.vim
+++ b/autoload/gutentags/cscope.vim
@@ -11,9 +11,12 @@ if !exists('g:gutentags_cscope_executable')
     let g:gutentags_cscope_executable = 'cscope'
 endif
 
-if !exists('g:gutentags_scopefile')
-    let g:gutentags_scopefile = 'cscope.out'
+if !exists('g:gutentags_cscope_filename')
+    let g:gutentags_cscope_filename = get(g:, 'gutentags_scopefile', 'cscope.out')
 endif
+function! gutentags#cscope#filename()
+    return g:gutentags_cscope_filename
+endfunction
 
 if !exists('g:gutentags_auto_add_cscope')
     let g:gutentags_auto_add_cscope = 1
@@ -28,7 +31,7 @@ let s:added_dbs = []
 
 function! gutentags#cscope#init(project_root) abort
     let l:dbfile_path = gutentags#get_cachefile(
-                \a:project_root, g:gutentags_scopefile)
+                \a:project_root, g:gutentags_cscope_filename)
     let b:gutentags_files['cscope'] = l:dbfile_path
 
     if g:gutentags_auto_add_cscope && filereadable(l:dbfile_path)

--- a/autoload/gutentags/ctags.vim
+++ b/autoload/gutentags/ctags.vim
@@ -6,9 +6,12 @@ if !exists('g:gutentags_ctags_executable')
     let g:gutentags_ctags_executable = 'ctags'
 endif
 
-if !exists('g:gutentags_tagfile')
-    let g:gutentags_tagfile = 'tags'
+if !exists('g:gutentags_ctags_filename')
+    let g:gutentags_ctags_filename = get(g:, 'gutentags_tagfile', 'tags')
 endif
+function! gutentags#ctags#filename()
+    return g:gutentags_ctags_filename
+endfunction
 
 if !exists('g:gutentags_auto_set_tags')
     let g:gutentags_auto_set_tags = 1
@@ -32,7 +35,7 @@ let s:unix_redir = (&shellredir =~# '%s') ? &shellredir : &shellredir . ' %s'
 function! gutentags#ctags#init(project_root) abort
     " Figure out the path to the tags file.
     let b:gutentags_files['ctags'] = gutentags#get_cachefile(
-                \a:project_root, g:gutentags_tagfile)
+                \a:project_root, g:gutentags_ctags_filename)
 
     " Set the tags file for Vim to use.
     if g:gutentags_auto_set_tags
@@ -72,7 +75,7 @@ function! gutentags#ctags#generate(proj_dir, tags_file, write_mode) abort
         " confused if the paths have spaces -- but not if you're *in* the
         " root directory.
         let l:actual_proj_dir = '.'
-        let l:actual_tags_file = g:gutentags_tagfile
+        let l:actual_tags_file = g:gutentags_ctags_filename
         execute "chdir " . fnameescape(a:proj_dir)
     else
         " else: the tags file goes in a cache directory, so we need to specify

--- a/doc/gutentags.txt
+++ b/doc/gutentags.txt
@@ -96,10 +96,10 @@ match one of the items in |gutentags_project_root|, create a file named
 "`.notags`" at the root of the project.
 
 The tag file that Gutentags creates and manages will be named after
-|gutentags_tagfile|, relative to the project's root directory. When Gutentags
-finds a valid project root, it will prepend the tag file's path to 'tags',
-unless |gutentags_auto_set_tags| is set to 0. This is to make sure Vim will use
-that file first.
+|gutentags_ctags_filename|, relative to the project's root directory.
+When Gutentags finds a valid project root, it will prepend the tag file's path
+to 'tags', unless |gutentags_auto_set_tags| is set to 0. This is to make sure
+Vim will use that file first.
 
 If a file managed by Gutentags is opened and no tag file already exists,
 Gutentags will start generating it right away in the background, unless 
@@ -220,8 +220,8 @@ g:gutentags_ctags_executable_{type}
                          let g:gutentags_ctags_executable_ruby = 'ripper-tags'
 <
 
-                                                *gutentags_tagfile*
-g:gutentags_tagfile
+                                                *gutentags_ctags_filename*
+g:gutentags_ctags_filename
                         Specifies the name of the tag file to create. This
                         will be appended to the project's root. See
                         |gutentags_project_root| for how Gutentags locates the
@@ -236,8 +236,8 @@ g:gutentags_project_root
                         in the current file's directory and its parent
                         directories. If it finds any of those markers,
                         Gutentags will be enabled for the project, and a tags
-                        file named after |gutentags_tagfile| will be created at
-                        the project root.
+                        file named after |gutentags_ctag_filename| will be
+                        created at the project root.
                         Defaults to `[]` (an empty |List|).
                         A list of default markers will always be appended to
                         the user-defined ones: ['.git', '.hg', '.bzr',

--- a/plugin/gutentags.vim
+++ b/plugin/gutentags.vim
@@ -54,6 +54,10 @@ if !exists('g:gutentags_project_root')
 endif
 let g:gutentags_project_root += ['.git', '.hg', '.svn', '.bzr', '_darcs', '_FOSSIL_', '.fslckout']
 
+if !exists('g:gutentags_use_generated_file_marker')
+    let g:gutentags_use_generated_file_marker = 1
+endif
+
 if !exists('g:gutentags_project_info')
     let g:gutentags_project_info = []
 endif


### PR DESCRIPTION
With g:gutentags_use_generated_file_marker (TODO: document) it will look
for e.g. `tags` first to find the "project" root.

Ref: https://github.com/ludovicchabant/vim-gutentags/issues/74