### PR TITLE
Skip buffer setup process when not necessary

### DIFF
--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -187,16 +187,6 @@ function! gutentags#setup_gutentags() abort
     " We know what tags file to manage! Now set things up.
     call gutentags#trace("Setting gutentags for buffer '" . bufname('%'))
 
-    " Autocommands for updating the tags on save.
-    let l:bn = bufnr('%')
-    execute 'augroup gutentags_buffer_' . l:bn
-    execute '  autocmd!'
-    execute '  autocmd BufWritePost <buffer=' . l:bn . '> call s:write_triggered_update_tags()'
-    execute 'augroup end'
-
-    " Miscellaneous commands.
-    command! -buffer -bang GutentagsUpdate :call s:manual_update_tags(<bang>0)
-
     " Add these tags files to the known tags files.
     for module in keys(b:gutentags_files)
         let l:tagfile = b:gutentags_files[module]
@@ -258,7 +248,7 @@ function! gutentags#get_execute_cmd_suffix() abort
 endfunction
 
 " (Re)Generate the tags file for the current buffer's file.
-function! s:manual_update_tags(bang) abort
+function! gutentags#manual_update_tags(bang) abort
     for module in g:gutentags_modules
         call s:update_tags(module, a:bang, 0)
     endfor
@@ -266,7 +256,7 @@ function! s:manual_update_tags(bang) abort
 endfunction
 
 " (Re)Generate the tags file for a buffer that just go saved.
-function! s:write_triggered_update_tags() abort
+function! gutentags#write_triggered_update_tags() abort
     if g:gutentags_enabled && g:gutentags_generate_on_write
         for module in g:gutentags_modules
             call s:update_tags(module, 0, 2)
@@ -285,6 +275,10 @@ endfunction
 "   1: if an update is already in progress, abort silently.
 "   2: if an update is already in progress, queue another one.
 function! s:update_tags(module, write_mode, queue_mode) abort
+    if !exists('b:gutentags_files')
+        call gutentags#setup_gutentags()
+    endif
+
     " Figure out where to save.
     let l:tags_file = b:gutentags_files[a:module]
     let l:proj_dir = b:gutentags_root

--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -277,6 +277,9 @@ endfunction
 function! s:update_tags(module, write_mode, queue_mode) abort
     if !exists('b:gutentags_files')
         call gutentags#setup_gutentags()
+        if !exists('b:gutentags_files')
+            return
+        endif
     endif
 
     " Figure out where to save.

--- a/plugin/gutentags.vim
+++ b/plugin/gutentags.vim
@@ -111,10 +111,25 @@ endif
 
 " Gutentags Setup {{{
 
+" Autocommands for updating the tags on save.
+augroup gutentags_buffer
+    autocmd!
+    autocmd BufWritePost <buffer> call gutentags#write_triggered_update_tags()
+augroup end'
+
+function! s:lazy_setup()
+    if g:gutentags_generate_on_new
+                \ || g:gutentags_generate_on_missing
+                \ || (get(g:, 'gutentags_auto_set_tags', 1)
+                \     && index(g:gutentags_modules, 'ctags') != -1)
+        call gutentags#setup_gutentags()
+    endif
+endfunction
+
 augroup gutentags_detect
     autocmd!
-    autocmd BufNewFile,BufReadPost *  call gutentags#setup_gutentags()
-    autocmd VimEnter               *  if expand('<amatch>')==''|call gutentags#setup_gutentags()|endif
+    autocmd BufNewFile,BufReadPost *  call s:lazy_setup()
+    autocmd VimEnter               *  if expand('<amatch>')=='' | call s:lazy_setup() | endif
 augroup end
 
 " }}}
@@ -122,6 +137,7 @@ augroup end
 " Toggles and Miscellaneous Commands {{{
 
 command! GutentagsUnlock :call gutentags#delete_lock_files()
+command! -bang GutentagsUpdate :call gutentags#manual_update_tags(<bang>0)
 
 if g:gutentags_define_advanced_commands
     command! GutentagsToggleEnabled :let g:gutentags_enabled=!g:gutentags_enabled


### PR DESCRIPTION
With the following settings, it is not necessary and can be skipped:

    let g:gutentags_generate_on_new = 0
    let g:gutentags_generate_on_missing = 0
    let g:gutentags_auto_set_tags = 0
    set tags=./tags;/

It will still be triggered on write and if the global config switches
get changed.