### PR TITLE
expand() g:gutentags_ctags_executable

### DIFF
--- a/autoload/gutentags/ctags.vim
+++ b/autoload/gutentags/ctags.vim
@@ -2,25 +2,11 @@
 
 " Global Options {{{
 
-if !exists('g:gutentags_ctags_executable')
-    let g:gutentags_ctags_executable = 'ctags'
-endif
-
-if !exists('g:gutentags_tagfile')
-    let g:gutentags_tagfile = 'tags'
-endif
-
-if !exists('g:gutentags_auto_set_tags')
-    let g:gutentags_auto_set_tags = 1
-endif
-
-if !exists('g:gutentags_ctags_options_file')
-    let g:gutentags_ctags_options_file = '.gutctags'
-endif
-
-if !exists('g:gutentags_ctags_check_tagfile')
-    let g:gutentags_ctags_check_tagfile = 0
-endif
+let g:gutentags_ctags_executable = get(g:, 'gutentags_ctags_executable', 'ctags')
+let g:gutentags_tagfile = get(g:, 'gutentags_tagfile', 'tags')
+let g:gutentags_auto_set_tags = get(g:, 'gutentags_auto_set_tags', 1)
+let g:gutentags_ctags_options_file = get(g:, 'gutentags_ctags_options_file', '.gutctags')
+let g:gutentags_ctags_check_tagfile = get(g:, 'gutentags_ctags_check_tagfile', 0)
 
 " }}}
 
@@ -40,7 +26,7 @@ function! gutentags#ctags#init(project_root) abort
     endif
 
     " Check if the ctags executable exists.
-    if g:gutentags_enabled && executable(g:gutentags_ctags_executable) == 0
+    if g:gutentags_enabled && executable(expand(g:gutentags_ctags_executable, 1)) == 0
         let g:gutentags_enabled = 0
         echoerr "Executable '".g:gutentags_ctags_executable."' can't be found. "
                     \."Gutentags will be disabled. You can re-enable it by "
@@ -156,11 +142,9 @@ function! s:get_ctags_executable(proj_dir) abort
     let l:ftype = get(split(&filetype, '\.'), 0, '')
     let l:proj_info = gutentags#get_project_info(a:proj_dir)
     let l:type = get(l:proj_info, 'type', l:ftype)
-    if exists('g:gutentags_ctags_executable_{l:type}')
-        return g:gutentags_ctags_executable_{l:type}
-    else
-        return g:gutentags_ctags_executable
-    endif
+    let exepath = exists('g:gutentags_ctags_executable_{l:type}')
+        \ ? g:gutentags_ctags_executable_{l:type} : g:gutentags_ctags_executable
+    return expand(exepath, 1)
 endfunction
 
 function! s:process_options_file(proj_dir, path) abort

--- a/plugin/gutentags.vim
+++ b/plugin/gutentags.vim
@@ -9,9 +9,7 @@ if v:version < 704
     finish
 endif
 
-if !exists('g:gutentags_debug')
-    let g:gutentags_debug = 0
-endif
+let g:gutentags_debug = get(g:, 'gutentags_debug', 0)
 
 if (exists('g:loaded_gutentags') || &cp) && !g:gutentags_debug
     finish
@@ -21,64 +19,26 @@ if (exists('g:loaded_gutentags') && g:gutentags_debug)
 endif
 let g:loaded_gutentags = 1
 
-if !exists('g:gutentags_trace')
-    let g:gutentags_trace = 0
-endif
+let g:gutentags_trace = get(g:, 'gutentags_trace', 0)
+let g:gutentags_fake = get(g:, 'gutentags_fake', 0)
+let g:gutentags_background_update = get(g:, 'gutentags_background_update', 1)
+let g:gutentags_pause_after_update = get(g:, 'gutentags_pause_after_update', 0)
+let g:gutentags_enabled = get(g:, 'gutentags_enabled', 1)
+let g:gutentags_enabled_user_func = get(g:, 'gutentags_enabled_user_func', '')
+let g:gutentags_modules = get(g:, 'gutentags_modules', ['ctags'])
 
-if !exists('g:gutentags_fake')
-    let g:gutentags_fake = 0
-endif
-
-if !exists('g:gutentags_background_update')
-    let g:gutentags_background_update = 1
-endif
-
-if !exists('g:gutentags_pause_after_update')
-    let g:gutentags_pause_after_update = 0
-endif
-
-if !exists('g:gutentags_enabled')
-    let g:gutentags_enabled = 1
-endif
-
-if !exists('g:gutentags_enabled_user_func')
-    let g:gutentags_enabled_user_func = ''
-endif
-
-if !exists('g:gutentags_modules')
-    let g:gutentags_modules = ['ctags']
-endif
-
-if !exists('g:gutentags_project_root')
-    let g:gutentags_project_root = []
-endif
+let g:gutentags_project_root = get(g:, 'gutentags_project_root', [])
 let g:gutentags_project_root += ['.git', '.hg', '.svn', '.bzr', '_darcs', '_FOSSIL_', '.fslckout']
 
-if !exists('g:gutentags_project_info')
-    let g:gutentags_project_info = []
-endif
+let g:gutentags_project_info = get(g:, 'gutentags_project_info', [])
 call add(g:gutentags_project_info, {'type': 'python', 'file': 'setup.py'})
 call add(g:gutentags_project_info, {'type': 'ruby', 'file': 'Gemfile'})
 
-if !exists('g:gutentags_exclude')
-    let g:gutentags_exclude = []
-endif
-
-if !exists('g:gutentags_resolve_symlinks')
-    let g:gutentags_resolve_symlinks = 0
-endif
-
-if !exists('g:gutentags_generate_on_new')
-    let g:gutentags_generate_on_new = 1
-endif
-
-if !exists('g:gutentags_generate_on_missing')
-    let g:gutentags_generate_on_missing = 1
-endif
-
-if !exists('g:gutentags_generate_on_write')
-    let g:gutentags_generate_on_write = 1
-endif
+let g:gutentags_exclude = get(g:, 'gutentags_exclude', [])
+let g:gutentags_resolve_symlinks = get(g:, 'gutentags_resolve_symlinks', 0)
+let g:gutentags_generate_on_new = get(g:, 'gutentags_generate_on_new', 1)
+let g:gutentags_generate_on_missing = get(g:, 'gutentags_generate_on_missing', 1)
+let g:gutentags_generate_on_write = get(g:, 'gutentags_generate_on_write', 1)
 
 if !exists('g:gutentags_cache_dir')
     let g:gutentags_cache_dir = ''
@@ -89,9 +49,7 @@ else
     let g:gutentags_cache_dir = fnamemodify(g:gutentags_cache_dir, ':s?[/\\]$??')
 endif
 
-if !exists('g:gutentags_define_advanced_commands')
-    let g:gutentags_define_advanced_commands = 0
-endif
+let g:gutentags_define_advanced_commands = get(g:, 'gutentags_define_advanced_commands', 0)
 
 if g:gutentags_cache_dir != '' && !isdirectory(g:gutentags_cache_dir)
     call mkdir(g:gutentags_cache_dir, 'p')


### PR DESCRIPTION
Allows "~/..." paths to work.

Also squash verbose code.