### PR TITLE
Use scope-local functions

### DIFF
--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -2,6 +2,23 @@
 
 " Utilities {{{
 
+function! gutentags#pwd()
+  if has('nvim')
+    return haslocaldir() ? getcwd(0, 0) : haslocaldir(-1, 0) ? getcwd(-1, 0) : getcwd()
+  else
+    return haslocaldir() ? getcwd(0, 0) : getcwd()
+  endif
+endfunction
+
+function! gutentags#chdir(path)
+  if has('nvim')
+    let chdir = haslocaldir() ? 'lcd' : haslocaldir(-1, 0) ? 'tcd' : 'cd'
+  else
+    let chdir = haslocaldir() ? 'lcd' : 'cd'
+  endif
+  execute chdir a:path
+endfunction
+
 " Throw an exception message.
 function! gutentags#throw(message)
     let v:errmsg = "gutentags: " . a:message
@@ -362,8 +379,8 @@ function! s:update_tags(bufno, module, write_mode, queue_mode) abort
     " Switch to the project root to make the command line smaller, and make
     " it possible to get the relative path of the filename to parse if we're
     " doing an incremental update.
-    let l:prev_cwd = getcwd()
-    execute "chdir " . fnameescape(l:proj_dir)
+    let l:prev_cwd = gutentags#pwd()
+    call gutentags#chdir(fnameescape(l:proj_dir))
     try
         call call("gutentags#".a:module."#generate",
                     \[l:proj_dir, l:tags_file, a:write_mode])
@@ -372,7 +389,7 @@ function! s:update_tags(bufno, module, write_mode, queue_mode) abort
         echom v:exception
     finally
         " Restore the current directory...
-        execute "chdir " . fnameescape(l:prev_cwd)
+        call gutentags#chdir(fnameescape(l:prev_cwd))
     endtry
 endfunction
 

--- a/autoload/gutentags/cscope.vim
+++ b/autoload/gutentags/cscope.vim
@@ -64,7 +64,7 @@ function! gutentags#cscope#generate(proj_dir, tags_file, write_mode) abort
     let l:cmd .= gutentags#get_execute_cmd_suffix()
 
     call gutentags#trace("Running: " . l:cmd)
-    call gutentags#trace("In:      " . getcwd())
+    call gutentags#trace("In:      " . gutentags#pwd())
     if !g:gutentags_fake
         if !(has('nvim') && exists('*jobwait'))
             if !g:gutentags_trace

--- a/autoload/gutentags/ctags.vim
+++ b/autoload/gutentags/ctags.vim
@@ -37,7 +37,7 @@ endfunction
 function! gutentags#ctags#generate(proj_dir, tags_file, write_mode) abort
     " Get to the tags file directory because ctags is finicky about
     " these things.
-    let l:prev_cwd = getcwd()
+    let l:prev_cwd = gutentags#pwd()
     let l:tags_file_exists = filereadable(a:tags_file)
 
     if l:tags_file_exists && g:gutentags_ctags_check_tagfile
@@ -59,7 +59,7 @@ function! gutentags#ctags#generate(proj_dir, tags_file, write_mode) abort
         " root directory.
         let l:actual_proj_dir = '.'
         let l:actual_tags_file = g:gutentags_tagfile
-        execute "chdir " . fnameescape(a:proj_dir)
+        call gutentags#chdir(fnameescape(a:proj_dir))
     else
         " else: the tags file goes in a cache directory, so we need to specify
         " all the paths absolutely for `ctags` to do its job correctly.
@@ -121,7 +121,7 @@ function! gutentags#ctags#generate(proj_dir, tags_file, write_mode) abort
         let l:cmd .= gutentags#get_execute_cmd_suffix()
 
         call gutentags#trace("Running: " . l:cmd)
-        call gutentags#trace("In:      " . getcwd())
+        call gutentags#trace("In:      " . gutentags#pwd())
         if !g:gutentags_fake
             " Run the background process.
             if !g:gutentags_trace
@@ -139,7 +139,7 @@ function! gutentags#ctags#generate(proj_dir, tags_file, write_mode) abort
         call gutentags#trace("")
     finally
         " Restore the previous working directory.
-        execute "chdir " . fnameescape(l:prev_cwd)
+        call gutentags#chdir(fnameescape(l:prev_cwd))
     endtry
 endfunction
 


### PR DESCRIPTION
This avoids overriding local cwd settings, as vim allows `lcd`
for window-local working directory and neovim supports additionally `tcd`
for tab-local working directory.
