### PR TITLE
Enable Project Root Finder

### DIFF
--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -104,7 +104,7 @@ endfunction
 " Finds the first directory with a project marker by walking up from the given
 " file path.
 function! gutentags#get_project_root(path) abort
-    if g:gutentags_project_root_finder
+    if g:gutentags_project_root_finder != ''
         return call(g:gutentags_project_root_finder, [a:path])
     endif
 

--- a/plugin/gutentags.vim
+++ b/plugin/gutentags.vim
@@ -32,7 +32,8 @@ let g:gutentags_project_root = get(g:, 'gutentags_project_root', [])
 if g:gutentags_add_default_project_roots
     let g:gutentags_project_root += ['.git', '.hg', '.svn', '.bzr', '_darcs', '_FOSSIL_', '.fslckout']
 endif
-let g:gutentags_project_root_finder = ''
+
+let g:gutentags_project_root_finder = get(g:, 'gutentags_project_root_finder', '')
 
 let g:gutentags_project_info = get(g:, 'gutentags_project_info', [])
 call add(g:gutentags_project_info, {'type': 'python', 'file': 'setup.py'})


### PR DESCRIPTION
Only set project root finder to blank if not already set and test
explicitly for a non blank setting to see if it has been set.

Even if it was set in .vimrc g:gutentags_project_root_finder was always set blank.
Once it was set it was not being called because it was not being recognised as set.

