### PR TITLE
Bug Fix: escape reserved Vim patterns in wildignore entries.

### DIFF
--- a/autoload/gutentags/ctags.vim
+++ b/autoload/gutentags/ctags.vim
@@ -145,7 +145,7 @@ function! gutentags#ctags#generate(proj_dir, tags_file, write_mode) abort
         endif
         if g:gutentags_ctags_exclude_wildignore
             for ign in split(&wildignore, ',')
-                let l:cmd .= ' -x ' . '"' . ign . '"'
+                let l:cmd .= ' -x ' . shellescape(ign, 1)
             endfor
         endif
         for exc in g:gutentags_ctags_exclude


### PR DESCRIPTION
Hello,

This is a bug fix for a case where execution of ctags command gets malformed, causing Vim to throw an error due to reserved characters not being properly escaped.

The specific error I've come across is `E194: No alternate file name to substitute for '#'`, due to an Emacs entry `.\#*` in a project's gitignore (populating wildignore through a plugin).

This commit addresses that issue, so that Emacs and Vim users can peacefully co-exist.

edit (2017-01-22):
I would also like to mention that this bug is for the most part silent, and can only be traced if your debugging options are set, or when stepping through the code
The exception to this is the side-effect that you won't be able to save a file in a given repo, without  first getting an E13 error (File exists), having to force write, which will then surface the error E194 mentioned above and then subsequently E170 (Missing :endfor)

Cheers,
Thaer