### PR TITLE
Fix db path of 'gtags-cscope' module on Windows.

### DIFF
--- a/autoload/gutentags/gtags_cscope.vim
+++ b/autoload/gutentags/gtags_cscope.vim
@@ -52,7 +52,9 @@ endfunction
 function! gutentags#gtags_cscope#init(project_root) abort
 	let l:db_path = gutentags#get_cachefile(
 				\ a:project_root, g:gutentags_gtags_dbpath )
-	let l:db_file = l:db_path . '/GTAGS'
+    let l:db_path = gutentags#stripslash(l:db_path)
+    let l:db_file = l:db_path . '/GTAGS'
+    let l:db_file = gutentags#normalizepath(l:db_file)
 
 	if !isdirectory(l:db_path)
 		call mkdir(l:db_path, 'p')


### PR DESCRIPTION
If g:gutentags_gtags_dbpath is not set, l:db_path would have a slash at the end, like
> ~\test_path\

And on Windows, l:db_file would be
> ~\test_path\\/GTAGS

which makes add_db function broken.