### PR TITLE
Don't apply `wildignore` when looking for markers

### DIFF
--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -155,7 +155,7 @@ function! gutentags#get_project_root(path) abort
     endif
     while l:path != l:previous_path
         for root in l:markers
-            if !empty(globpath(l:path, root))
+            if !empty(globpath(l:path, root, 1))
                 let l:proj_dir = simplify(fnamemodify(l:path, ':p'))
                 let l:proj_dir = gutentags#stripslash(l:proj_dir)
                 if l:proj_dir == ''


### PR DESCRIPTION
When folks have `.git` in their `wildignore`, the `globpath` function will never find a project marker. The fix uses an argument which disables ignoring files with this function.

Fixes an issue where `gutentag#get_project_root` never found a project marker, thus, failing `gutentags#setup_gutentags` and none know the wiser. Once you enable the trace command, it's already too late, hard to debug.