### PR TITLE
Replace matchstrpos() with match() + split() for backwards compatibility

### DIFF
--- a/autoload/gutentags/ctags.vim
+++ b/autoload/gutentags/ctags.vim
@@ -116,10 +116,10 @@ function! gutentags#ctags#generate(proj_dir, tags_file, write_mode) abort
         else
             let l:file_list_cmd = gutentags#get_project_file_list_cmd(l:actual_proj_dir)
             if !empty(l:file_list_cmd)
-                let l:suffopts = matchstrpos(l:file_list_cmd, '///')
-                if l:suffopts[1] > 0
-                    let l:suffoptstr = strpart(l:file_list_cmd, l:suffopts[2])
-                    let l:file_list_cmd = strpart(l:file_list_cmd, 0, l:suffopts[1])
+                if match(l:file_list_cmd, '///') > 0
+                    let l:suffopts = split(l:file_list_cmd, '///')
+                    let l:suffoptstr = l:suffopts[1]
+                    let l:file_list_cmd = l:suffopts[0]
                     if l:suffoptstr == 'absolute'
                         let l:cmd .= ' -A'
                     endif


### PR DESCRIPTION
`matchstrpos()` was added to Vim as patch 7.4.1685: http://ftp.vim.org/vim/patches/7.4/7.4.1685

Older but still vendor-supported operating systems (such as Ubuntu 14.04 LTS and derivatives) ship versions of Vim that predate this patch. Replacing `matchstrpos()` allows vim-gutentags to continue to work with these older versions of Vim.

Issue: https://github.com/ludovicchabant/vim-gutentags/issues/114

----

**Note:** I'm not entirely sure what the exact `g:gutentags_file_list_command` setting is supposed to be to configure the file list command with absolute output paths. I tested with:

```vim
let g:gutentags_file_list_command = {
    \ 'markers': {
        \ '.git': 'git ls-files -co --exclude-standard///absolute',
        \ },
    \ }
```

Please let me know if this isn't the right setting value for that feature.