### PR TITLE
Fix cscope generation use of proj_dir

### DIFF
--- a/autoload/gutentags/cscope.vim
+++ b/autoload/gutentags/cscope.vim
@@ -56,7 +56,7 @@ function! gutentags#cscope#generate(proj_dir, tags_file, write_mode) abort
     let l:cmd .= ' -p ' . a:proj_dir
     let l:cmd .= ' -f ' . a:tags_file
     let l:file_list_cmd =
-        \ gutentags#get_project_file_list_cmd(l:proj_dir)
+        \ gutentags#get_project_file_list_cmd(a:proj_dir)
     if !empty(l:file_list_cmd)
         let l:cmd .= ' -L "' . l:file_list_cmd . '"'
     endif


### PR DESCRIPTION
There is a typo in `gutentags#cscope#generate` where `gutentags#get_project_file_list_cmd` was using `l:proj_dir` (undefined) instead of `a:proj_dir`.  This was preventing the scope module from working.

This PR simply corrects the typo.