### PR TITLE
Fix cscope generation

### DIFF
--- a/autoload/gutentags/cscope.vim
+++ b/autoload/gutentags/cscope.vim
@@ -34,7 +34,7 @@ function! gutentags#cscope#init(project_root) abort
     if g:gutentags_auto_add_cscope && filereadable(l:dbfile_path)
         if index(s:added_dbs, l:dbfile_path) < 0
             call add(s:added_dbs, l:dbfile_path)
-            execute 'cs add ' . fnameescape(l:dbfile_path)
+            silent! execute 'cs add ' . fnameescape(l:dbfile_path)
         endif
     endif
 endfunction
@@ -43,7 +43,7 @@ function! gutentags#cscope#command_terminated(job_id, data, event) abort
     if a:data == 0
         if index(s:added_dbs, self.db_file) < 0
             call add(s:added_dbs, self.db_file)
-            execute 'cs add ' . fnameescape(s:db_file)
+            silent! execute 'cs add ' . fnameescape(s:db_file)
         else
             execute 'cs reset'
         endif

--- a/autoload/gutentags/cscope.vim
+++ b/autoload/gutentags/cscope.vim
@@ -24,6 +24,7 @@ endif
 " Gutentags Module Interface {{{
 
 let s:runner_exe = gutentags#get_plat_file('update_scopedb')
+let s:unix_redir = (&shellredir =~# '%s') ? &shellredir : &shellredir . ' %s'
 let s:added_dbs = []
 
 function! gutentags#cscope#init(project_root) abort
@@ -59,6 +60,17 @@ function! gutentags#cscope#generate(proj_dir, tags_file, write_mode) abort
         \ gutentags#get_project_file_list_cmd(a:proj_dir)
     if !empty(l:file_list_cmd)
         let l:cmd .= ' -L "' . l:file_list_cmd . '"'
+    endif
+    if g:gutentags_trace
+        if has('win32')
+            let l:cmd .= ' -l "' . a:tags_file . '.log"'
+        else
+            let l:cmd .= ' ' . printf(s:unix_redir, '"' . a:tags_file . '.log"')
+        endif
+    else
+        if !has('win32')
+            let l:cmd .= ' ' . printf(s:unix_redir, '/dev/null')
+        endif
     endif
     let l:cmd .= ' '
     let l:cmd .= gutentags#get_execute_cmd_suffix()

--- a/autoload/gutentags/cscope.vim
+++ b/autoload/gutentags/cscope.vim
@@ -56,7 +56,7 @@ function! gutentags#cscope#generate(proj_dir, tags_file, write_mode) abort
     let l:cmd .= ' -p ' . a:proj_dir
     let l:cmd .= ' -f ' . a:tags_file
     let l:file_list_cmd =
-        \ gutentags#get_project_file_list_cmd(l:proj_dir)
+        \ gutentags#get_project_file_list_cmd(a:proj_dir)
     if !empty(l:file_list_cmd)
         let l:cmd .= ' -L "' . l:file_list_cmd . '"'
     endif

--- a/plat/unix/update_scopedb.sh
+++ b/plat/unix/update_scopedb.sh
@@ -69,10 +69,10 @@ if [ -n "${FILE_LIST_CMD}" ]; then
             echo "${PROJECT_ROOT%/}/${l}"
         done > "${DB_FILE}.files"
     fi
-    CSCOPE_ARGS="${CSCOPE_ARGS} -i ${DB_FILE}.files"
 else
-    CSCOPE_ARGS="${CSCOPE_ARGS} -R"
+    find . -type f > "${DB_FILE}.files"
 fi
+CSCOPE_ARGS="${CSCOPE_ARGS} -i ${DB_FILE}.files"
 
 echo "Running cscope"
 echo "$CSCOPE_EXE $CSCOPE_ARGS -b -k -f \"$DB_FILE.temp\""


### PR DESCRIPTION
- As mentioned in #141, using `l:proj_dir` causes an error. This should be fixed immediately.
- Just calling `cscope -R` won't work for Homebrew cscope. It instead raises an error:

   ```
   cscope: no source files found
   ```
   So I used simple `find . -type f`.
- `gutentags#ctags#generate` redirects output to `l:actual_tags_file . '.log'` or `/dev/null`, but `gutentags#cscope#generate` doesn't. It makes the output displays on Vim. So I added logging feature, and updated `plat/win32/update_scopedb.cmd`.