### PR TITLE
Ignore tags files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
This PR adds a .gitignore to supplement the existing .hgignore file to disregard generated tags files.