### PR TITLE
Ads an info finder. Adds a type option to the file list command dictionary. Improves doc.

### DIFF
--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -105,6 +105,8 @@ function! s:cache_project_root(path) abort
     endfor
     endif
 
+    call gutentags#trace("Adding ".a:path." to known projects: ".get(l:result,'type','no type'))
+
     let s:known_projects[a:path] = l:result
 endfunction
 
@@ -123,20 +125,25 @@ function! gutentags#get_project_file_list_cmd(proj_dir) abort
         if type(l:markers) == type({})
             for [marker, file_list_cmd] in items(l:markers)
                 if !empty(globpath(a:proj_dir, marker, 1))
+                    call gutentags#trace("Found marker matching project: ".marker.". using file list command: '".file_list_cmd."'.")
                     return gutentags#validate_cmd(file_list_cmd)
                 endif
             endfor
         endif
         let l:types = get(g:gutentags_file_list_command, 'types', {})
         if !empty(l:types) && type(l:types) == type({})
-            let l:proj_info = gutentags#get_project_info(a:proj_dir)
+            let l:proj_dir = gutentags#stripslash(simplify(fnamemodify(a:proj_dir, ":p")))
+            let l:proj_info = gutentags#get_project_info(l:proj_dir)
+            call gutentags#trace("Found project info: type: ".get(l:proj_info, 'type', 'empty'))
             if l:proj_info != {}
                 let l:file_list_cmd = get(l:types, l:proj_info['type'], '')
                 if !empty(l:file_list_cmd)
+                    call gutentags#trace("Found type matching project: ".l:proj_info['type'].". using file list command: '".l:file_list_cmd."'.")
                     return gutentags#validate_cmd(l:file_list_cmd)
                 endif
             endif
         endif
+        call gutentags#trace("Using default find command '".get(g:gutentags_file_list_command, 'default', "")."'.")
         return gutentags#validate_cmd(get(g:gutentags_file_list_command, 'default', ""))
     endif
     return ""

--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -98,105 +98,11 @@ function! s:get_project_info(path) abort
     return get(s:known_projects, a:path, {})
 endfunction
 
-" Get info on the project we're inside of.
-function! gutentags#get_project_info(path) abort
-    let l:result = {}
-
-    for proj_info in g:gutentags_project_info
-        let l:filematch = get(proj_info, 'file', '')
-        let l:type = get(proj_info, 'type', '')
-        if l:filematch != '' && filereadable(a:path . '/'. l:filematch)
-            let l:result = copy(proj_info)
-            break
-        endif
-
-        let l:globmatch = get(proj_info, 'glob', '')
-        if l:globmatch != '' && glob(a:path . '/' . l:globmatch) != ''
-            let l:result = copy(proj_info)
-            break
-        endif
-    endfor
-
-    return l:result
-endfunction
-
 function! gutentags#validate_cmd(cmd) abort
     if !empty(a:cmd) && executable(split(a:cmd)[0])
         return a:cmd
     endif
     return ""
-endfunction
-
-function! gutentags#get_project_file_list_cmd(proj_root, proj_type) abort
-
-    if type(g:gutentags_file_list_command) == type("")
-        return gutentags#validate_cmd(g:gutentags_file_list_command)
-    elseif type(g:gutentags_file_list_command) == type({})
-        let l:markers = get(g:gutentags_file_list_command, 'markers', {})
-        if type(l:markers) == type({})
-            for [marker, file_list_cmd] in items(l:markers)
-                if !empty(globpath(a:proj_root, marker, 1))
-                    call gutentags#trace("Found marker matching project: ".marker.". using file list command: '".file_list_cmd."'.")
-                    return gutentags#validate_cmd(file_list_cmd)
-                endif
-            endfor
-        endif
-        let l:types = get(g:gutentags_file_list_command, 'types', {})
-        if !empty(l:types) && type(l:types) == type({})
-            let l:file_list_cmd = get(l:types, a:proj_type, '')
-            if !empty(l:file_list_cmd)
-                call gutentags#trace("Found type matching project: ".l:proj_info['type'].". using file list command: '".l:file_list_cmd."'.")
-                return gutentags#validate_cmd(l:file_list_cmd)
-            endif
-        endif
-        call gutentags#trace("Using default find command '".get(g:gutentags_file_list_command, 'default', "")."'.")
-        return gutentags#validate_cmd(get(g:gutentags_file_list_command, 'default', ""))
-    endif
-    return ""
-endfunction
-
-" Finds the first directory with a project marker by walking up from the given
-" file path.
-function! gutentags#get_project_root(path) abort
-    let l:path = gutentags#stripslash(a:path)
-    let l:previous_path = ""
-    let l:markers = g:gutentags_project_root[:]
-    if exists('g:ctrlp_root_markers')
-        for crm in g:ctrlp_root_markers
-            if index(l:markers, crm) < 0
-                call add(l:markers, crm)
-            endif
-        endfor
-    endif
-    while l:path != l:previous_path
-        for root in l:markers
-            if !empty(globpath(l:path, root, 1))
-                let l:proj_dir = simplify(fnamemodify(l:path, ':p'))
-                let l:proj_dir = gutentags#stripslash(l:proj_dir)
-                if l:proj_dir == ''
-                    call gutentags#trace("Found project marker '" . root .
-                                \"' at the root of your file-system! " .
-                                \" That's probably wrong, disabling " .
-                                \"gutentags for this file...",
-                                \1)
-                    call gutentags#throw("Marker found at root, aborting.")
-                endif
-                for ign in g:gutentags_exclude_project_root
-                    if l:proj_dir == ign
-                        call gutentags#trace(
-                                    \"Ignoring project root '" . l:proj_dir .
-                                    \"' because it is in the list of ignored" .
-                                    \" projects.")
-                        call gutentags#throw("Ignore project: " . l:proj_dir)
-                    endif
-                endfor
-                return l:proj_dir
-            endif
-        endfor
-        let l:previous_path = l:path
-        let l:path = fnamemodify(l:path, ':h')
-    endwhile
-    call gutentags#throw("Can't figure out what tag file to use for: " . a:path)
 endfunction
 
 " Generate a path for a given filename in the cache directory.

--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -3,12 +3,12 @@
 " Utilities {{{
 
 function! gutentags#chdir(path)
-  if has('nvim')
-    let chdir = haslocaldir() ? 'lcd' : haslocaldir(-1, 0) ? 'tcd' : 'cd'
-  else
-    let chdir = haslocaldir() ? 'lcd' : 'cd'
-  endif
-  execute chdir a:path
+    if has('nvim')
+        let chdir = haslocaldir() ? 'lcd' : haslocaldir(-1, 0) ? 'tcd' : 'cd'
+    else
+        let chdir = haslocaldir() ? 'lcd' : 'cd'
+    endif
+    execute chdir a:path
 endfunction
 
 " Throw an exception message.
@@ -24,10 +24,10 @@ endfunction
 
 " Prints a message if debug tracing is enabled.
 function! gutentags#trace(message, ...)
-   if g:gutentags_trace || (a:0 && a:1)
-       let l:message = "gutentags: " . a:message
-       echom l:message
-   endif
+    if g:gutentags_trace || (a:0 && a:1)
+        let l:message = "gutentags: " . a:message
+        echom l:message
+    endif
 endfunction
 
 " Strips the ending slash in a path.
@@ -48,11 +48,11 @@ endfunction
 
 " Shell-slashes the path (opposite of `normalizepath`).
 function! gutentags#shellslash(path)
-  if exists('+shellslash') && !&shellslash
-    return substitute(a:path, '\v\\', '/', 'g')
-  else
-    return a:path
-  endif
+    if exists('+shellslash') && !&shellslash
+        return substitute(a:path, '\v\\', '/', 'g')
+    else
+        return a:path
+    endif
 endfunction
 
 " Gets a file path in the correct `plat` folder.
@@ -67,14 +67,14 @@ endfunction
 
 " Returns whether a path is rooted.
 if has('win32') || has('win64')
-function! gutentags#is_path_rooted(path) abort
-  return len(a:path) >= 2 && (
-        \a:path[0] == '/' || a:path[0] == '\' || a:path[1] == ':')
-endfunction
+    function! gutentags#is_path_rooted(path) abort
+        return len(a:path) >= 2 && (
+                    \a:path[0] == '/' || a:path[0] == '\' || a:path[1] == ':')
+    endfunction
 else
-function! gutentags#is_path_rooted(path) abort
-  return !empty(a:path) && a:path[0] == '/'
-endfunction
+    function! gutentags#is_path_rooted(path) abort
+        return !empty(a:path) && a:path[0] == '/'
+    endfunction
 endif
 
 " }}}
@@ -87,11 +87,24 @@ let s:known_projects = {}
 function! s:cache_project_root(path) abort
     let l:result = {}
 
-    if g:gutentags_project_info_finder != ''
-        let l:result = call(g:gutentags_project_info_finder, [a:path])
-    else
+    let l:result = call(g:gutentags_project_info_finder, [a:path])
+
+    call gutentags#trace("Adding ".a:path." to known projects: ".get(l:result,'type','no type'))
+
+    let s:known_projects[a:path] = l:result
+endfunction
+
+function! s:get_project_info(path) abort
+    return get(s:known_projects, a:path, {})
+endfunction
+
+" Get info on the project we're inside of.
+function! gutentags#get_project_info(path) abort
+    let l:result = {}
+
     for proj_info in g:gutentags_project_info
         let l:filematch = get(proj_info, 'file', '')
+        let l:type = get(proj_info, 'type', '')
         if l:filematch != '' && filereadable(a:path . '/'. l:filematch)
             let l:result = copy(proj_info)
             break
@@ -103,11 +116,8 @@ function! s:cache_project_root(path) abort
             break
         endif
     endfor
-    endif
 
-    call gutentags#trace("Adding ".a:path." to known projects: ".get(l:result,'type','no type'))
-
-    let s:known_projects[a:path] = l:result
+    return l:result
 endfunction
 
 function! gutentags#validate_cmd(cmd) abort
@@ -117,14 +127,15 @@ function! gutentags#validate_cmd(cmd) abort
     return ""
 endfunction
 
-function! gutentags#get_project_file_list_cmd(proj_dir) abort
+function! gutentags#get_project_file_list_cmd(proj_root, proj_type) abort
+
     if type(g:gutentags_file_list_command) == type("")
         return gutentags#validate_cmd(g:gutentags_file_list_command)
     elseif type(g:gutentags_file_list_command) == type({})
         let l:markers = get(g:gutentags_file_list_command, 'markers', {})
         if type(l:markers) == type({})
             for [marker, file_list_cmd] in items(l:markers)
-                if !empty(globpath(a:proj_dir, marker, 1))
+                if !empty(globpath(a:proj_root, marker, 1))
                     call gutentags#trace("Found marker matching project: ".marker.". using file list command: '".file_list_cmd."'.")
                     return gutentags#validate_cmd(file_list_cmd)
                 endif
@@ -132,15 +143,10 @@ function! gutentags#get_project_file_list_cmd(proj_dir) abort
         endif
         let l:types = get(g:gutentags_file_list_command, 'types', {})
         if !empty(l:types) && type(l:types) == type({})
-            let l:proj_dir = gutentags#stripslash(simplify(fnamemodify(a:proj_dir, ":p")))
-            let l:proj_info = gutentags#get_project_info(l:proj_dir)
-            call gutentags#trace("Found project info: type: ".get(l:proj_info, 'type', 'empty'))
-            if l:proj_info != {}
-                let l:file_list_cmd = get(l:types, l:proj_info['type'], '')
-                if !empty(l:file_list_cmd)
-                    call gutentags#trace("Found type matching project: ".l:proj_info['type'].". using file list command: '".l:file_list_cmd."'.")
-                    return gutentags#validate_cmd(l:file_list_cmd)
-                endif
+            let l:file_list_cmd = get(l:types, a:proj_type, '')
+            if !empty(l:file_list_cmd)
+                call gutentags#trace("Found type matching project: ".l:proj_info['type'].". using file list command: '".l:file_list_cmd."'.")
+                return gutentags#validate_cmd(l:file_list_cmd)
             endif
         endif
         call gutentags#trace("Using default find command '".get(g:gutentags_file_list_command, 'default', "")."'.")
@@ -151,11 +157,7 @@ endfunction
 
 " Finds the first directory with a project marker by walking up from the given
 " file path.
-function! gutentags#get_project_root(path, throw) abort
-    if g:gutentags_project_root_finder != ''
-        return call(g:gutentags_project_root_finder, [a:path])
-    endif
-
+function! gutentags#get_project_root(path) abort
     let l:path = gutentags#stripslash(a:path)
     let l:previous_path = ""
     let l:markers = g:gutentags_project_root[:]
@@ -172,28 +174,20 @@ function! gutentags#get_project_root(path, throw) abort
                 let l:proj_dir = simplify(fnamemodify(l:path, ':p'))
                 let l:proj_dir = gutentags#stripslash(l:proj_dir)
                 if l:proj_dir == ''
-                    if a:throw 
-                        call gutentags#trace("Found project marker '" . root .
-                                    \"' at the root of your file-system! " .
-                                    \" That's probably wrong, disabling " .
-                                    \"gutentags for this file...",
-                                    \1)
-                        call gutentags#throw("Marker found at root, aborting.")
-                    else
-                        return ""
-                    endif
+                    call gutentags#trace("Found project marker '" . root .
+                                \"' at the root of your file-system! " .
+                                \" That's probably wrong, disabling " .
+                                \"gutentags for this file...",
+                                \1)
+                    call gutentags#throw("Marker found at root, aborting.")
                 endif
                 for ign in g:gutentags_exclude_project_root
                     if l:proj_dir == ign
-                        if a:throw 
-                            call gutentags#trace(
-                                        \"Ignoring project root '" . l:proj_dir .
-                                        \"' because it is in the list of ignored" .
-                                        \" projects.")
-                            call gutentags#throw("Ignore project: " . l:proj_dir)
-                        else
-                            return ""
-                        endif
+                        call gutentags#trace(
+                                    \"Ignoring project root '" . l:proj_dir .
+                                    \"' because it is in the list of ignored" .
+                                    \" projects.")
+                        call gutentags#throw("Ignore project: " . l:proj_dir)
                     endif
                 endfor
                 return l:proj_dir
@@ -202,16 +196,7 @@ function! gutentags#get_project_root(path, throw) abort
         let l:previous_path = l:path
         let l:path = fnamemodify(l:path, ':h')
     endwhile
-    if a:throw 
-        call gutentags#throw("Can't figure out what tag file to use for: " . a:path)
-    else
-        return ""
-    endif
-endfunction
-
-" Get info on the project we're inside of.
-function! gutentags#get_project_info(path) abort
-    return get(s:known_projects, a:path, {})
+    call gutentags#throw("Can't figure out what tag file to use for: " . a:path)
 endfunction
 
 " Generate a path for a given filename in the cache directory.
@@ -244,7 +229,7 @@ function! gutentags#setup_gutentags() abort
     " Also don't do anything for the default `[No Name]` buffer you get
     " after starting Vim.
     if &buftype != '' || 
-          \(bufname('%') == '' && !g:gutentags_generate_on_empty_buffer)
+                \(bufname('%') == '' && !g:gutentags_generate_on_empty_buffer)
         return
     endif
 
@@ -264,7 +249,7 @@ function! gutentags#setup_gutentags() abort
             let l:buf_dir = fnamemodify(resolve(expand('%:p', 1)), ':p:h')
         endif
         if !exists('b:gutentags_root')
-            let b:gutentags_root = gutentags#get_project_root(l:buf_dir, 1)
+            let b:gutentags_root = call( g:gutentags_project_root_finder, [l:buf_dir])
         endif
         if filereadable(b:gutentags_root . '/.notags')
             call gutentags#trace("'.notags' file found... no gutentags support.")
@@ -274,10 +259,13 @@ function! gutentags#setup_gutentags() abort
         if !has_key(s:known_projects, b:gutentags_root)
             call s:cache_project_root(b:gutentags_root)
         endif
+        if !exists('b:gutentags_proj_type')
+            let l:proj_info = s:get_project_info(b:gutentags_root)
+            let b:gutentags_proj_type = get(l:proj_info, 'type', '')
+        endif
         if g:gutentags_trace
-            let l:projnfo = gutentags#get_project_info(b:gutentags_root)
-            if l:projnfo != {}
-                call gutentags#trace("Setting project type to ".l:projnfo['type'])
+            if b:gutentags_proj_type != ''
+                call gutentags#trace("Setting project type to ".b:gutentags_proj_type)
             else
                 call gutentags#trace("No specific project type.")
             endif
@@ -285,7 +273,7 @@ function! gutentags#setup_gutentags() abort
 
         let b:gutentags_files = {}
         for module in g:gutentags_modules
-            call call("gutentags#".module."#init", [b:gutentags_root])
+            call call("gutentags#".module."#init", [b:gutentags_root, b:gutentags_proj_type])
         endfor
     catch /^gutentags\:/
         call gutentags#trace("No gutentags support for this buffer.")
@@ -402,7 +390,8 @@ function! s:update_tags(bufno, module, write_mode, queue_mode) abort
     " Figure out where to save.
     let l:buf_gutentags_files = getbufvar(a:bufno, 'gutentags_files')
     let l:tags_file = l:buf_gutentags_files[a:module]
-    let l:proj_dir = getbufvar(a:bufno, 'gutentags_root')
+    let l:proj_root = getbufvar(a:bufno, 'gutentags_root')
+    let l:proj_type = getbufvar(a:bufno, 'gutentags_proj_type')
 
     " Check that there's not already an update in progress.
     let l:lock_file = l:tags_file . '.lock'
@@ -430,10 +419,10 @@ function! s:update_tags(bufno, module, write_mode, queue_mode) abort
     " it possible to get the relative path of the filename to parse if we're
     " doing an incremental update.
     let l:prev_cwd = getcwd()
-    call gutentags#chdir(fnameescape(l:proj_dir))
+    call gutentags#chdir(fnameescape(l:proj_root))
     try
         call call("gutentags#".a:module."#generate",
-                    \[l:proj_dir, l:tags_file, a:write_mode])
+                    \[l:proj_root, l:proj_type, l:tags_file, a:write_mode])
     catch /^gutentags\:/
         echom "Error while generating ".a:module." file:"
         echom v:exception

--- a/autoload/gutentags/ctags.vim
+++ b/autoload/gutentags/ctags.vim
@@ -15,6 +15,8 @@ let g:gutentags_ctags_extra_args_finder = get(g:, 'gutentags_ctags_extra_args_fi
 let g:gutentags_ctags_extra_args = get(g:, 'gutentags_ctags_extra_args', [])
 
 " ctags post process cmd
+let g:gutentags_ctags_post_process_cmd_finder = get(g:, 'gutentags_ctags_post_process_cmd_finder', 
+            \'')
 let g:gutentags_ctags_post_process_cmd = get(g:, 'gutentags_ctags_post_process_cmd', '')
 
 " ctags exclude
@@ -154,8 +156,14 @@ function! gutentags#ctags#generate(proj_root, proj_type, tags_file, write_mode) 
         let l:cmd .= ' -O '.shellescape(join(l:extra_args), 1)
     endif
     " ctags post process cmd
-    if !empty(g:gutentags_ctags_post_process_cmd)
-        let l:cmd .= ' -P '.shellescape(g:gutentags_ctags_post_process_cmd)
+    let l:post_process_cmd=''
+    if g:gutentags_ctags_post_process_cmd_finder != ''
+        let l:post_process_cmd = call(g:gutentags_ctags_post_process_cmd_finder, [a:proj_root, a:proj_type])
+    elseif !empty(g:gutentags_ctags_post_process_cmd)
+        let l:post_process_cmd = g:gutentags_ctags_post_process_cmd
+    endif
+    if !empty(l:post_process_cmd)
+        let l:cmd .= ' -P '.shellescape(l:post_process_cmd)
     endif
     let l:proj_options_file = a:proj_root . '/' .
                 \g:gutentags_ctags_options_file

--- a/autoload/gutentags/ctags.vim
+++ b/autoload/gutentags/ctags.vim
@@ -8,10 +8,20 @@ let g:gutentags_ctags_auto_set_tags = get(g:, 'gutentags_ctags_auto_set_tags', 1
 
 let g:gutentags_ctags_options_file = get(g:, 'gutentags_ctags_options_file', '.gutctags')
 let g:gutentags_ctags_check_tagfile = get(g:, 'gutentags_ctags_check_tagfile', 0)
+
+" ctags extra args 
+let g:gutentags_ctags_extra_args_finder = get(g:, 'gutentags_ctags_extra_args_finder', 
+            \'')
 let g:gutentags_ctags_extra_args = get(g:, 'gutentags_ctags_extra_args', [])
+
+" ctags post process cmd
 let g:gutentags_ctags_post_process_cmd = get(g:, 'gutentags_ctags_post_process_cmd', '')
 
+" ctags exclude
+let g:gutentags_ctags_exclude_finder = get(g:, 'gutentags_ctags_exclude_finder', 
+            \'')
 let g:gutentags_ctags_exclude = get(g:, 'gutentags_ctags_exclude', [])
+
 let g:gutentags_ctags_exclude_wildignore = get(g:, 'gutentags_ctags_exclude_wildignore', 1)
 
 " Backwards compatibility.
@@ -39,7 +49,7 @@ let s:did_check_exe = 0
 let s:runner_exe = gutentags#get_plat_file('update_tags')
 let s:unix_redir = (&shellredir =~# '%s') ? &shellredir : &shellredir . ' %s'
 
-function! gutentags#ctags#init(project_root) abort
+function! gutentags#ctags#init(proj_root, proj_type) abort
     " Figure out the path to the tags file.
     " Check the old name for this option, too, before falling back to the
     " globally defined name.
@@ -47,7 +57,7 @@ function! gutentags#ctags#init(project_root) abort
                 \getbufvar("", 'gutentags_tagfile', 
                 \g:gutentags_ctags_tagfile))
     let b:gutentags_files['ctags'] = gutentags#get_cachefile(
-                \a:project_root, l:tagfile)
+                \a:proj_root, l:tagfile)
 
     " Set the tags file for Vim to use.
     if g:gutentags_ctags_auto_set_tags
@@ -56,9 +66,10 @@ function! gutentags#ctags#init(project_root) abort
 
     " Check if the ctags executable exists.
     if s:did_check_exe == 0
-        if g:gutentags_enabled && executable(expand(g:gutentags_ctags_executable, 1)) == 0
+        let l:gutentags_ctags_executable =  s:get_ctags_executable(a:proj_root, a:proj_type)
+        if g:gutentags_enabled && executable(expand(l:gutentags_ctags_executable, 1)) == 0
             let g:gutentags_enabled = 0
-            echoerr "Executable '".g:gutentags_ctags_executable."' can't be found. "
+            echoerr "Executable '".l:gutentags_ctags_executable."' can't be found. "
                         \."Gutentags will be disabled. You can re-enable it by "
                         \."setting g:gutentags_enabled back to 1."
         endif
@@ -66,7 +77,8 @@ function! gutentags#ctags#init(project_root) abort
     endif
 endfunction
 
-function! gutentags#ctags#generate(proj_dir, tags_file, write_mode) abort
+function! gutentags#ctags#generate(proj_root, proj_type, tags_file, write_mode) abort
+    call gutentags#trace("updateing tags with: ".a:proj_root.", ".a:proj_type)
     let l:tags_file_exists = filereadable(a:tags_file)
     let l:tags_file_relative = fnamemodify(a:tags_file, ':.')
     let l:tags_file_is_local = len(l:tags_file_relative) < len(a:tags_file)
@@ -96,13 +108,13 @@ function! gutentags#ctags#generate(proj_dir, tags_file, write_mode) abort
     else
         " else: the tags file goes in a cache directory, so we need to specify
         " all the paths absolutely for `ctags` to do its job correctly.
-        let l:actual_proj_dir = a:proj_dir
+        let l:actual_proj_dir = a:proj_root
         let l:actual_tags_file = a:tags_file
     endif
 
     " Build the command line.
     let l:cmd = gutentags#get_execute_cmd() . s:runner_exe
-    let l:cmd .= ' -e "' . s:get_ctags_executable(a:proj_dir) . '"'
+    let l:cmd .= ' -e "' . s:get_ctags_executable(a:proj_root, a:proj_type) . '"'
     let l:cmd .= ' -t "' . l:actual_tags_file . '"'
     let l:cmd .= ' -p "' . l:actual_proj_dir . '"'
     if a:write_mode == 0 && l:tags_file_exists
@@ -112,7 +124,7 @@ function! gutentags#ctags#generate(proj_dir, tags_file, write_mode) abort
         endif
         let l:cmd .= ' -s "' . l:cur_file_path . '"'
     else
-        let l:file_list_cmd = gutentags#get_project_file_list_cmd(l:actual_proj_dir)
+        let l:file_list_cmd =call(g:gutentags_project_file_list_cmd_finder,[a:proj_root, a:proj_type])
         if !empty(l:file_list_cmd)
             if match(l:file_list_cmd, '///') > 0
                 let l:suffopts = split(l:file_list_cmd, '///')
@@ -122,7 +134,7 @@ function! gutentags#ctags#generate(proj_dir, tags_file, write_mode) abort
                     let l:cmd .= ' -A'
                 endif
             endif
-            let l:cmd .= ' -L ' . '"' . l:file_list_cmd. '"'
+            let l:cmd .= ' -L ' . shellescape(l:file_list_cmd)
         endif
     endif
     if empty(get(l:, 'file_list_cmd', ''))
@@ -131,27 +143,44 @@ function! gutentags#ctags#generate(proj_dir, tags_file, write_mode) abort
         " Omit --recursive if this project uses a file list command.
         let l:cmd .= ' -o "' . gutentags#get_res_file('ctags_recursive.options') . '"'
     endif
-    if !empty(g:gutentags_ctags_extra_args)
-        let l:cmd .= ' -O '.shellescape(join(g:gutentags_ctags_extra_args))
+    " ctags extra args
+    let l:extra_args = []
+    if g:gutentags_ctags_extra_args_finder != ''
+        let l:extra_args = call(g:gutentags_ctags_extra_args_finder, [a:proj_root, a:proj_type])
+    elseif !empty(g:gutentags_ctags_extra_args)
+        let l:extra_args = g:gutentags_ctags_extra_args
     endif
+    if !empty(l:extra_args)
+        let l:cmd .= ' -O '.shellescape(join(l:extra_args), 1)
+    endif
+    " ctags post process cmd
     if !empty(g:gutentags_ctags_post_process_cmd)
         let l:cmd .= ' -P '.shellescape(g:gutentags_ctags_post_process_cmd)
     endif
-    let l:proj_options_file = a:proj_dir . '/' .
+    let l:proj_options_file = a:proj_root . '/' .
                 \g:gutentags_ctags_options_file
     if filereadable(l:proj_options_file)
         let l:proj_options_file = s:process_options_file(
-                    \a:proj_dir, l:proj_options_file)
+                    \a:proj_root, l:proj_options_file)
         let l:cmd .= ' -o "' . l:proj_options_file . '"'
     endif
+    " ctags exclude
+    let l:exclude = []
+    if g:gutentags_ctags_exclude_finder != ''
+        let l:exclude = call(g:gutentags_ctags_exclude_finder, [a:proj_root, a:proj_type])
+    elseif !empty(g:gutentags_ctags_exclude)
+        let l:exclude = g:gutentags_ctags_exclude
+    endif
+    for exc in l:exclude
+        let l:cmd .= ' -x ' . '"' . exc . '"'
+    endfor
+
     if g:gutentags_ctags_exclude_wildignore
         for ign in split(&wildignore, ',')
             let l:cmd .= ' -x ' . shellescape(ign, 1)
         endfor
     endif
-    for exc in g:gutentags_ctags_exclude
-        let l:cmd .= ' -x ' . '"' . exc . '"'
-    endfor
+
     if g:gutentags_pause_after_update
         let l:cmd .= ' -c'
     endif
@@ -191,17 +220,15 @@ endfunction
 " Utilities {{{
 
 " Get final ctags executable depending whether a filetype one is defined
-function! s:get_ctags_executable(proj_dir) abort
+function! s:get_ctags_executable(proj_root, proj_type) abort
     "Only consider the main filetype in cases like 'python.django'
     let l:ftype = get(split(&filetype, '\.'), 0, '')
-    let l:proj_info = gutentags#get_project_info(a:proj_dir)
-    let l:type = get(l:proj_info, 'type', l:ftype)
-    let exepath = exists('g:gutentags_ctags_executable_{l:type}')
-        \ ? g:gutentags_ctags_executable_{l:type} : g:gutentags_ctags_executable
+    let exepath = exists('g:gutentags_ctags_executable_{a:proj_type}')
+                \ ? g:gutentags_ctags_executable_{a:proj_type} : g:gutentags_ctags_executable
     return expand(exepath, 1)
 endfunction
 
-function! s:process_options_file(proj_dir, path) abort
+function! s:process_options_file(proj_root, path) abort
     if empty(g:gutentags_cache_dir)
         " If we're not using a cache directory to store tag files, we can
         " use the options file straight away.
@@ -210,8 +237,8 @@ function! s:process_options_file(proj_dir, path) abort
 
     " See if we need to process the options file.
     let l:do_process = 0
-    let l:proj_dir = gutentags#stripslash(a:proj_dir)
-    let l:out_path = gutentags#get_cachefile(l:proj_dir, 'options')
+    let l:proj_root = gutentags#stripslash(a:proj_root)
+    let l:out_path = gutentags#get_cachefile(l:proj_root, 'options')
     if !filereadable(l:out_path)
         call gutentags#trace("Processing options file '".a:path."' because ".
                     \"it hasn't been processed yet.")
@@ -257,7 +284,7 @@ function! s:process_options_file(proj_dir, path) abort
             continue
         endif
 
-        let l:fullp = l:proj_dir . gutentags#normalizepath('/'.l:exarg)
+        let l:fullp = l:proj_root . gutentags#normalizepath('/'.l:exarg)
         let l:ol = '--exclude='.l:fullp
         call add(l:outlines, l:ol)
     endfor

--- a/autoload/gutentags/defaults.vim
+++ b/autoload/gutentags/defaults.vim
@@ -1,0 +1,96 @@
+" defaults.vim - default finders for Gutentags
+
+" Get info on the project we're inside of.
+function! gutentags#defaults#get_project_info(path) abort
+    let l:result = {}
+
+    for proj_info in g:gutentags_project_info
+        let l:filematch = get(proj_info, 'file', '')
+        let l:type = get(proj_info, 'type', '')
+        if l:filematch != '' && filereadable(a:path . '/'. l:filematch)
+            let l:result = copy(proj_info)
+            break
+        endif
+
+        let l:globmatch = get(proj_info, 'glob', '')
+        if l:globmatch != '' && glob(a:path . '/' . l:globmatch) != ''
+            let l:result = copy(proj_info)
+            break
+        endif
+    endfor
+
+    return l:result
+endfunction
+
+function! gutentags#defaults#get_project_file_list_cmd(proj_root, proj_type) abort
+
+    if type(g:gutentags_file_list_command) == type("")
+        return gutentags#validate_cmd(g:gutentags_file_list_command)
+    elseif type(g:gutentags_file_list_command) == type({})
+        let l:markers = get(g:gutentags_file_list_command, 'markers', {})
+        if type(l:markers) == type({})
+            for [marker, file_list_cmd] in items(l:markers)
+                if !empty(globpath(a:proj_root, marker, 1))
+                    call gutentags#trace("Found marker matching project: ".marker.". using file list command: '".file_list_cmd."'.")
+                    return gutentags#validate_cmd(file_list_cmd)
+                endif
+            endfor
+        endif
+        let l:types = get(g:gutentags_file_list_command, 'types', {})
+        if !empty(l:types) && type(l:types) == type({})
+            let l:file_list_cmd = get(l:types, a:proj_type, '')
+            if !empty(l:file_list_cmd)
+                call gutentags#trace("Found type matching project: ".l:proj_info['type'].". using file list command: '".l:file_list_cmd."'.")
+                return gutentags#validate_cmd(l:file_list_cmd)
+            endif
+        endif
+        call gutentags#trace("Using default find command '".get(g:gutentags_file_list_command, 'default', "")."'.")
+        return gutentags#validate_cmd(get(g:gutentags_file_list_command, 'default', ""))
+    endif
+    return ""
+endfunction
+
+" Finds the first directory with a project marker by walking up from the given
+" file path.
+function! gutentags#defaults#get_project_root(path) abort
+    let l:path = gutentags#stripslash(a:path)
+    let l:previous_path = ""
+    let l:markers = g:gutentags_project_root[:]
+    if exists('g:ctrlp_root_markers')
+        for crm in g:ctrlp_root_markers
+            if index(l:markers, crm) < 0
+                call add(l:markers, crm)
+            endif
+        endfor
+    endif
+    while l:path != l:previous_path
+        for root in l:markers
+            if !empty(globpath(l:path, root, 1))
+                let l:proj_dir = simplify(fnamemodify(l:path, ':p'))
+                let l:proj_dir = gutentags#stripslash(l:proj_dir)
+                if l:proj_dir == ''
+                    call gutentags#trace("Found project marker '" . root .
+                                \"' at the root of your file-system! " .
+                                \" That's probably wrong, disabling " .
+                                \"gutentags for this file...",
+                                \1)
+                    call gutentags#throw("Marker found at root, aborting.")
+                endif
+                for ign in g:gutentags_exclude_project_root
+                    if l:proj_dir == ign
+                        call gutentags#trace(
+                                    \"Ignoring project root '" . l:proj_dir .
+                                    \"' because it is in the list of ignored" .
+                                    \" projects.")
+                        call gutentags#throw("Ignore project: " . l:proj_dir)
+                    endif
+                endfor
+                return l:proj_dir
+            endif
+        endfor
+        let l:previous_path = l:path
+        let l:path = fnamemodify(l:path, ':h')
+    endwhile
+    call gutentags#throw("Can't figure out what tag file to use for: " . a:path)
+endfunction
+

--- a/doc/gutentags.txt
+++ b/doc/gutentags.txt
@@ -332,7 +332,7 @@ g:gutentags_ctags_extra_args
                         Defaults to `[]` (an empty |List|).
 
                                                 *gutentags_ctags_extra_tags_finder*
-g:gutentags_ctags_exclude_finder
+g:gutentags_ctags_extra_tags_finder
                         The name of a function which will be called with two
                         strings, first the project root then the project type.
                         It should return a list like

--- a/doc/gutentags.txt
+++ b/doc/gutentags.txt
@@ -32,7 +32,8 @@
 2. Commands                 |gutentags-commands|
 3. Status Line              |gutentags-status-line|
 4. Global Settings          |gutentags-settings|
-5. Project Settings         |gutentags-project-settings|
+5. Buffer Variables         |gutentags-buffer-variables|
+6. Project Settings         |gutentags-project-settings|
 
 =============================================================================
 1. Introduction                                 *gutentags-intro*
@@ -311,8 +312,8 @@ g:gutentags_project_root_finder
                         When a buffer is loaded, Gutentags uses a default
                         (internal) implementation to find that file's
                         project's root directory, using settings like
-                        |g:gutentags_project_root|. When you specify
-                        |g:gutentags_project_root_finder|, you can tell
+                        |gutentags_project_root|. When you specify
+                        |gutentags_project_root_finder|, you can tell
                         Gutentags to use a custom implementation, such as
                         `vim-projectroot`. The value of this setting must be
                         the name of a function that takes a single string
@@ -320,8 +321,33 @@ g:gutentags_project_root_finder
                         returns a string value (the project's root directory).
                         Defaults to `''`.
                         Note: when set, the called implementation will most 
-                        likely ignore |g:gutentags_project_root|.
+                        likely ignore |gutentags_project_root|.
 
+                                                *gutentags_ctags_extra_args*
+g:gutentags_ctags_extra_args
+                        A list of strings to pass to the
+                        |gutentags_ctags_executable|. These can be used for
+                        general arguments that ctags will use for 
+                        tags generation.
+                        Defaults to `[]` (an empty |List|).
+
+                                                *gutentags_ctags_extra_tags_finder*
+g:gutentags_ctags_exclude_finder
+                        The name of a function which will be called with two
+                        strings, first the project root then the project type.
+                        It should return a list like
+                        |gutentags_ctags_extra_args|.
+                        Defaults to `''` (an empty |String|)
+                        For example:
+                        >
+                            let g:gutentags_ctags_extra_args_finder = 'MyExtraArgs'
+                            function! MyExtraArgs(proj_type)
+                                if a:proj_type == 'cpp'
+                                    return ['--kinds-c++=defgmpstuc', '--fields=+Z+l+p-k+K+z+n+s']
+                                endif
+                                return []
+                            endfunction
+<
                                                 *gutentags_ctags_exclude*
 g:gutentags_ctags_exclude
                         A list of file patterns to pass to the
@@ -330,6 +356,22 @@ g:gutentags_ctags_exclude
                         See also |gutentags_ctags_exclude_wildignore|.
                         Defaults to `[]` (an empty |List|).
 
+                                                *gutentags_ctags_exclude_finder*
+g:gutentags_ctags_exclude_finder
+                        This names a function which will be called with two
+                        strings, first the project root then the project type.
+                        It should return a list like gutentags_ctags_exclude|.
+                        Defaults to `''` (an empty |String|)
+                        For example:
+                        >
+                            let g:gutentags_ctags_exclude_finder = 'MyExcludedFiles'
+                            function! MyExcludedFiles(proj_root, proj_type)
+                                if a:proj_type == 'cpp'
+                                    return ["*.xml", "*.html"]
+                                endif
+                                return []
+                            endfunction
+<
                                                 *gutentags_ctags_exclude_wildignore*
 g:gutentags_ctags_exclude_wildignore
                         When 1, Gutentags will automatically pass your
@@ -442,7 +484,7 @@ g:gutentags_init_user_func
                         `gutentags_enabled_user_func`. The old setting is
                         still used as a fallback.
 
-                        Defaults to "".
+                        Defaults to `''` (an empty |String|).
 
                                             *gutentags_define_advanced_commands*
 g:gutentags_define_advanced_commands
@@ -496,7 +538,21 @@ g:gutentags_project_info_finder
                         containing at least a 'type'.  Note: when set, the
                         called implementation will ignore
                         |g:gutentags_project_info|. As such the 'glob' and
-                        'file' tags will be ignored.  Defaults to `''`.  
+                        'file' tags will be ignored.  
+                        Defaults to `''` (An empty |String|).  
+
+                        For example:
+                        >
+                        let g:gutentags_project_info_finder = 'GetProjectInfo'
+                        function! GetProjectInfo(proj_root)
+                            if a:proj_root == '~/CppWorkspace'
+                                return { 'type': 'cpp' }
+                            else
+                                return {}
+                            endif
+                        endfunction
+>
+<
 
                                             *gutentags_file_list_command*
 g:gutentags_file_list_command
@@ -550,7 +606,30 @@ g:gutentags_file_list_command
                         read the list of files to be examined.
 
 =============================================================================
-5. Project Settings                             *gutentags-project-settings*
+5. Buffer Variables                             *gutentags-buffer-variables*
+
+Gutentafs sets up two significant bufferlocal varaibles. They can be queried
+to provide project information to a=other scripts. Or they can be set
+directly by the in the |gutentags_init_user_finc| to bypass teh usual settup.
+They are:
+
+                                                            *gutentags_root*
+b:gutentags_root
+                        This stores the root directory of the project that
+                        this buffer is in. It is computed either with
+                        internally through the |gutentags_project_root|
+                        setting, or by the user with the function named by 
+                        |gutentags_project_root_finder|.
+
+                                                        *gutentags_proj_type*
+b:gutentags_proj_type
+                        This stores the type of project that this buffer is
+                        in. It is either computed internally with
+                        |gutentags_project_info|, or it by the user with the
+                        function named by |gutentags_project_info_finder|.
+
+=============================================================================
+6. Project Settings                             *gutentags-project-settings*
 
 Gutentags can be customized to some extent on a per-project basis with the
 following files present in the project root directory:

--- a/doc/gutentags.txt
+++ b/doc/gutentags.txt
@@ -461,16 +461,16 @@ g:gutentags_project_info
                         Each dictionary item must contain at least a `type`
                         key, indicating the type of project:
 
-                        {"type": "python"}
+                        {'type': 'python'}
 
                         Other items will be used to figure out if a project is
                         of the given type.
 
-                        "file": any existing file with this path (relative to
+                        'file': any existing file with this path (relative to
                         the project root) will make the current project match
                         the given info.
 
-                        "glob": any result found with this glob pattern
+                        'glob': any result found with this glob pattern
                         (relative to the project root) will make the current
                         project match the given info. See |glob()| for more
                         information.
@@ -484,6 +484,19 @@ g:gutentags_project_info
                         `g:gutentags_ctags_executable_ruby` out of the box.
                         See |gutentags_ctags_executable_{filetype}| for more
                         information.
+
+                                                *gutentags_project_info_finder*
+g:gutentags_project_info_finder
+                        Usually Gutentags uses |g:gutentags_project_info| to
+                        specify the information for a project.  You can
+                        override that behaviour by setting
+                        |g:gutentags_project_info_finder| to the name of a
+                        function. It takes as an argument the path to the root
+                        of the project and should return a |Dictionary|
+                        containing at least a 'type'.  Note: when set, the
+                        called implementation will ignore
+                        |g:gutentags_project_info|. As such the 'glob' and
+                        'file' tags will be ignored.  Defaults to `''`.  
 
                                             *gutentags_file_list_command*
 g:gutentags_file_list_command
@@ -507,13 +520,29 @@ g:gutentags_file_list_command
                         as a mapping of project root markers to the desired
                         file list command for that root marker. (See
                         |gutentags_project_root| for how Gutentags uses root
-                        markers to locate the project.) For example: >
+                        markers to locate the project.) 
+                        The |Dictionary| can have a 'markers' key, which is a
+                        dictionary of project markers to commands.
+                        The |Dictionary| can have a 'types' key, which is a
+                        dictionary of project types to commands. Note that
+                        'markers' take precidnt over the 'kinds' key.
+                        The |Dictionary| may have a 'default' key, which will
+                        be used if there is no matching marker.  
+                        If a valid marker is found it will be used. Otherwise
+                        if a valid type is found that will be used. Finally
+                        the default will be used.
+
+                        For example: >
 
                          let g:gutentags_file_list_command = {
                              \ 'markers': {
                                  \ '.git': 'git ls-files',
                                  \ '.hg': 'hg files',
                                  \ },
+                             \ 'types': {
+                                 \ 'python': 'find . -name "*.py"'
+                                 \ },
+                             \ 'default': 'find . -type f'
                              \ }
 <
                         Note: If a custom ctags executable is specified, it

--- a/plugin/gutentags.vim
+++ b/plugin/gutentags.vim
@@ -40,6 +40,7 @@ if g:gutentags_add_default_project_roots
 endif
 
 let g:gutentags_project_root_finder = get(g:, 'gutentags_project_root_finder', '')
+let g:gutentags_project_info_finder = get(g:, 'gutentags_project_info_finder', '')
 
 let g:gutentags_project_info = get(g:, 'gutentags_project_info', [])
 call add(g:gutentags_project_info, {'type': 'python', 'file': 'setup.py'})

--- a/plugin/gutentags.vim
+++ b/plugin/gutentags.vim
@@ -33,11 +33,11 @@ let g:gutentags_modules = get(g:, 'gutentags_modules', ['ctags'])
 let g:gutentags_init_user_func = get(g:, 'gutentags_init_user_func', get(g:, 'gutentags_enabled_user_func', ''))
 
 let g:gutentags_project_root_finder = get(g:, 'gutentags_project_root_finder', 
-            \'gutentags#get_project_root')
+            \'gutentags#defaults#get_project_root')
 let g:gutentags_project_info_finder = get(g:, 'gutentags_project_info_finder', 
-            \'gutentags#get_project_info')
+            \'gutentags#defaults#get_project_info')
 let g:gutentags_project_file_list_cmd_finder = get(g:, 'gutentags_project_file_list_cmd_finder',
-            \'gutentags#get_project_file_list_cmd')
+            \'gutentags#defaults#get_project_file_list_cmd')
 
 " settings for gutentags#get_project_root
 let g:gutentags_add_default_project_roots = get(g:, 'gutentags_add_default_project_roots', 1)

--- a/plugin/gutentags.vim
+++ b/plugin/gutentags.vim
@@ -30,29 +30,36 @@ let g:gutentags_pause_after_update = get(g:, 'gutentags_pause_after_update', 0)
 let g:gutentags_enabled = get(g:, 'gutentags_enabled', 1)
 let g:gutentags_modules = get(g:, 'gutentags_modules', ['ctags'])
 
-let g:gutentags_init_user_func = get(g:, 'gutentags_init_user_func', 
-            \get(g:, 'gutentags_enabled_user_func', ''))
+let g:gutentags_init_user_func = get(g:, 'gutentags_init_user_func', get(g:, 'gutentags_enabled_user_func', ''))
 
+let g:gutentags_project_root_finder = get(g:, 'gutentags_project_root_finder', 
+            \'gutentags#get_project_root')
+let g:gutentags_project_info_finder = get(g:, 'gutentags_project_info_finder', 
+            \'gutentags#get_project_info')
+let g:gutentags_project_file_list_cmd_finder = get(g:, 'gutentags_project_file_list_cmd_finder',
+            \'gutentags#get_project_file_list_cmd')
+
+" settings for gutentags#get_project_root
 let g:gutentags_add_default_project_roots = get(g:, 'gutentags_add_default_project_roots', 1)
 let g:gutentags_project_root = get(g:, 'gutentags_project_root', [])
 if g:gutentags_add_default_project_roots
     let g:gutentags_project_root += ['.git', '.hg', '.svn', '.bzr', '_darcs', '_FOSSIL_', '.fslckout']
 endif
+let g:gutentags_exclude_project_root = get(g:, 'gutentags_exclude_project_root', ['/usr/local'])
 
-let g:gutentags_project_root_finder = get(g:, 'gutentags_project_root_finder', '')
-let g:gutentags_project_info_finder = get(g:, 'gutentags_project_info_finder', '')
-
+" settings for gutentags#get_project_info
 let g:gutentags_project_info = get(g:, 'gutentags_project_info', [])
 call add(g:gutentags_project_info, {'type': 'python', 'file': 'setup.py'})
 call add(g:gutentags_project_info, {'type': 'ruby', 'file': 'Gemfile'})
 
-let g:gutentags_exclude_project_root = get(g:, 'gutentags_exclude_project_root', ['/usr/local'])
+" settings for gutentags#get_project_file_list_cmd
+let g:gutentags_file_list_command = get(g:, 'gutentags_file_list_command', '')
+
 let g:gutentags_resolve_symlinks = get(g:, 'gutentags_resolve_symlinks', 0)
 let g:gutentags_generate_on_new = get(g:, 'gutentags_generate_on_new', 1)
 let g:gutentags_generate_on_missing = get(g:, 'gutentags_generate_on_missing', 1)
 let g:gutentags_generate_on_write = get(g:, 'gutentags_generate_on_write', 1)
 let g:gutentags_generate_on_empty_buffer = get(g:, 'gutentags_generate_on_empty_buffer', 0)
-let g:gutentags_file_list_command = get(g:, 'gutentags_file_list_command', '')
 
 if !exists('g:gutentags_cache_dir')
     let g:gutentags_cache_dir = ''


### PR DESCRIPTION
Improved the documentation for gutentags_file_list_command.
Adds the 'types' value to the same dictionary.
Adds the capacity to set g:gutentags_project_info_finder, which
overrides the gutentags_project_info options.
This is the same as the way the g:gutentags_project_root_finder
overrides the gutentags_project_root.

I've also made the get_project_root take a flag on whether or not to throw. I do this so that I can use it in my status line.

Please check that the way I have changed the documentation is in line with your style of writing.

I must confess I have not followed your contribution guidelines, especially not the testing bit. But as you can see the changes should not have large ramifications.