### PR TITLE
Fix arguments to gutentags#default_io_cb()

### DIFF
--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -559,7 +559,7 @@ if has('nvim')
     endfunction
 
     function! s:nvim_job_out_wrapper(real_cb, job, lines, event_type) abort
-        call call(a:real_cb, [a:lines])
+        call call(a:real_cb, [a:job, a:lines])
     endfunction
 
     function! gutentags#build_default_job_options(module) abort


### PR DESCRIPTION
caused by 6327f37ab22999943ec925a7c8de8c32be366165