### PR TITLE
Suppress warnings from cscope reset

### DIFF
--- a/autoload/gutentags/cscope.vim
+++ b/autoload/gutentags/cscope.vim
@@ -73,7 +73,7 @@ function! gutentags#cscope#on_job_exit(job, exit_val) abort
             call add(s:added_dbs, l:dbfile_path)
             silent! execute 'cs add ' . fnameescape(l:dbfile_path)
         else
-            execute 'cs reset'
+            silent! execute 'cs reset'
         endif
     else
         call gutentags#warning(


### PR DESCRIPTION
This is a follow-up of #146.