### PR TITLE
Fix gutentags_file_list_command behavior

### DIFF
--- a/plat/unix/update_tags.sh
+++ b/plat/unix/update_tags.sh
@@ -117,6 +117,8 @@ if [ $INDEX_WHOLE_PROJECT -eq 1 ]; then
             done > "${TAGS_FILE}.files"
         fi
         CTAGS_ARGS="${CTAGS_ARGS} -L ${TAGS_FILE}.files"
+        # Clear project root if we have a file list
+        PROJECT_ROOT=""
     fi
     echo "Running ctags on whole project"
     echo "$CTAGS_EXE -f \"$TAGS_FILE.temp\" $CTAGS_ARGS \"$PROJECT_ROOT\""


### PR DESCRIPTION
If we clear the project directory when we have a file list, ctags won't ignore the `-L` command and run on only the files provided.

Addresses the issue I brought up here:
https://github.com/ludovicchabant/vim-gutentags/issues/101