### PR TITLE
Fix file list command in `update_scope.sh`

### DIFF
--- a/plat/unix/update_scopedb.sh
+++ b/plat/unix/update_scopedb.sh
@@ -62,10 +62,10 @@ fi
 
 if [ -n "${FILE_LIST_CMD}" ]; then
     if [ "${PROJECT_ROOT}" = "." ]; then
-        $FILE_LIST_CMD > "${DB_FILE}.files"
+        eval "$FILE_LIST_CMD" > "${DB_FILE}.files"
     else
         # If using a tags cache directory, use absolute paths
-        $FILE_LIST_CMD | while read -r l; do
+        eval "$FILE_LIST_CMD" | while read -r l; do
             echo "${PROJECT_ROOT%/}/${l}"
         done > "${DB_FILE}.files"
     fi


### PR DESCRIPTION
Prepend `eval` and surround `$FILE_LIST_CMD` with double quotes to make sure the command actually works if there are single or double quotes in the command string. 
For example `find . -type f -iname "*.php"'`. That would fail without the `eval` command. Double quotes are usually needed when list or pattern is expected, only in a few situation you can omit them safely so I rather put them for safety.