### PR TITLE
Use "cmd /c script.cmd" under Windows

### DIFF
--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -64,7 +64,7 @@ endfunction
 
 " Gets a file path in the correct `plat` folder.
 function! gutentags#get_plat_file(filename) abort
-    return g:gutentags_plat_dir . a:filename . g:gutentags_script_ext
+    return g:gutentags_shell . g:gutentags_plat_dir . a:filename . g:gutentags_script_ext
 endfunction
 
 " Gets a file path in the resource folder.

--- a/plugin/gutentags.vim
+++ b/plugin/gutentags.vim
@@ -76,10 +76,12 @@ if g:gutentags_cache_dir != '' && !isdirectory(g:gutentags_cache_dir)
 endif
 
 if has('win32')
+    let g:gutentags_shell = 'cmd /c '
     let g:gutentags_plat_dir = expand('<sfile>:h:h:p') . "\\plat\\win32\\"
     let g:gutentags_res_dir = expand('<sfile>:h:h:p') . "\\res\\"
     let g:gutentags_script_ext = '.cmd'
 else
+    let g:gutentags_shell = ''
     let g:gutentags_plat_dir = expand('<sfile>:h:h:p') . '/plat/unix/'
     let g:gutentags_res_dir = expand('<sfile>:h:h:p') . '/res/'
     let g:gutentags_script_ext = '.sh'


### PR DESCRIPTION
Otherwise starting the job just immediately fails.

---

I've been using a rather old version of this plugin for a long time but decided to update to the newest one today, only to discover that it just didn't do anything at all for me any longer. After some debugging I found that `job_start()` simply failed, i.e. returned "0 failed", and AFAICS this is the intended behaviour with Vim as its documentation explicitly states that the command is run without any shell and `.cmd` scripts are not really executable under Windows. So I've fixed it using the commit here and now things seem to work fine, however I'm very surprised that I'm the only one running into this issue, so I could be missing something here.

In any case, i.e. even if you don't apply this fix, I think `gutentags#add_job()` should check if the job couldn't be started successfully and give an error in this case instead of waiting for the job termination callback which will be never called in this case.