### PR TITLE
Improve docs concerning gtags_cscope module

### DIFF
--- a/doc/gutentags.txt
+++ b/doc/gutentags.txt
@@ -333,7 +333,7 @@ g:gutentags_project_root
                         A list of default markers will be appended to the
                         user-defined ones unless
                         |gutentags_add_default_project_roots| is set to 0.
-                        
+
                                             *gutentags_add_default_project_roots*
 g:gutentags_add_default_project_roots
                         Defines whether Gutentags should always define some
@@ -642,7 +642,20 @@ The following settings are valid for the `gtags_cscope` module.
 g:gutentags_gtags_executable
                         Specifies the name or path of the `gtags` executable
                         to use to generate the code database.
-                        Default to `"gtags"`.
+                        Defaults to `"gtags"`.
+
+                                                *gutentags_gtags_cscope_executable*
+g:gutentags_gtags_cscope_executable
+                        Specifies the name or path of the `gtags-cscope`
+                        executable to use to generate the code database.
+                        Defaults to `"gtags-cscope"`.
+
+                                                *gutentags_gtags_dbpath*
+g:gutentags_gtags_dbpath
+                        Path from the cache directory (|gutentags_cache_dir|
+                        or project root) to the folder containing the
+                        definition database file (usually called `GTAGS`).
+                        Defaults to `""`.
 
                                                 *gutentags_gtags_options_file*
 g:gutentags_gtags_options_file
@@ -660,9 +673,9 @@ g:gutentags_auto_add_gtags_cscope
 
 People using `cscope` or `gtags_cscope` across multiple projects in the same
 Vim instance might be interested in the `gutentags_plus` plugin, which handles
-switching databases automatically before performing a query. 
+switching databases automatically before performing a query.
 See https://github.com/skywind3000/gutentags_plus.
-      
+
 =============================================================================
 5. Project Settings                             *gutentags-project-settings*
 


### PR DESCRIPTION
Add missing parameters, fix typos and remove some whitespaces.

Missing parameters were `g:gutentags_gtags_dbpath` and `g:gutentags_gtags_cscope_executable`.