### PR TITLE
add enabled_on_missing feature

### DIFF
--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -324,7 +324,7 @@ function! gutentags#setup_gutentags() abort
 
             " Generate this new file depending on settings and stuff.
             if g:gutentags_enabled
-                if g:gutentags_generate_on_missing && !filereadable(l:tagfile)
+                if !filereadable(l:tagfile) && g:gutentags_enabled_on_missing && g:gutentags_generate_on_missing
                     call gutentags#trace("Generating missing tags file: " . l:tagfile)
                     call s:update_tags(l:bn, module, 1, 1)
                 elseif g:gutentags_generate_on_new
@@ -449,8 +449,10 @@ endfunction
 " (Re)Generate the tags file for a buffer that just go saved.
 function! s:write_triggered_update_tags(bufno) abort
     if g:gutentags_enabled && g:gutentags_generate_on_write
-        for module in g:gutentags_modules
-            call s:update_tags(a:bufno, module, 0, 2)
+        for module in g:gutentags_modules 
+            if filereadable(b:gutentags_files[module]) || g:gutentags_enabled_on_missing 
+                call s:update_tags(a:bufno, module, 0, 2)
+            endif
         endfor
     endif
     silent doautocmd User GutentagsUpdating

--- a/doc/gutentags.txt
+++ b/doc/gutentags.txt
@@ -274,6 +274,13 @@ g:gutentags_enabled
                         don't.
                         Defaults to `1`.
 
+                                                *gutentags_enabled_on_missing*
+g:gutentags_enabled_on_missing
+                        Defines whether Gutentags should be enabled when no
+                        tag file is found.  This will naturally overwrite
+                        |gutentags_generate_on_missing|.
+                        Defaults to `1`.
+
                                                 *gutentags_trace*
 g:gutentags_trace
                         When true, Gutentags will spit out debugging

--- a/plugin/gutentags.vim
+++ b/plugin/gutentags.vim
@@ -33,6 +33,7 @@ let g:gutentags_fake = get(g:, 'gutentags_fake', 0)
 let g:gutentags_background_update = get(g:, 'gutentags_background_update', 1)
 let g:gutentags_pause_after_update = get(g:, 'gutentags_pause_after_update', 0)
 let g:gutentags_enabled = get(g:, 'gutentags_enabled', 1)
+let g:gutentags_enabled_on_missing = get(g:, 'gutentags_enabled_on_missing', 1)
 let g:gutentags_modules = get(g:, 'gutentags_modules', ['ctags'])
 
 let g:gutentags_init_user_func = get(g:, 'gutentags_init_user_func', 


### PR DESCRIPTION
Not sure if anyone else would want this feature, but I sometimes just don't want to generate tag files automatically, but whenever there's already a tags file I hope it to be up-to-date. 
It's like genereate_on_missing=0 and at the same time, when missing, don't generate_on_write. 
Hope this is helpful. 