### PR TITLE
Fix file listing for cscope on Windows

### DIFF
--- a/plat/win32/update_scopedb.cmd
+++ b/plat/win32/update_scopedb.cmd
@@ -64,12 +64,12 @@ if NOT ["%FILE_LIST_CMD%"]==[""] (
     ) else (
         rem Potentially useful:
         rem http://stackoverflow.com/questions/9749071/cmd-iterate-stdin-piped-from-another-command
-        %FILE_LIST_CMD% | for /F "usebackq delims=" %%F in (`findstr "."`) do @echo %PROJECT_ROOT%\%%F > %DB_FILE%.files
+        for /F "usebackq delims=" %%F in (`%FILE_LIST_CMD%`) do @echo "%PROJECT_ROOT%\%%F">%DB_FILE%.files
     )
-    set CSCOPE_ARGS=%CSCOPE_ARGS% -i %TAGS_FILE%.files
 ) ELSE (
-    set CSCOPE_ARGS=%CSCOPE_ARGS% -R
+    for /F "usebackq delims=" %%F in (`dir /S /B /A-D .`) do @echo "%%F">%DB_FILE%.files
 )
+set CSCOPE_ARGS=%CSCOPE_ARGS% -i %DB_FILE%.files
 "%CSCOPE_EXE%" %CSCOPE_ARGS% -b -k -f "%DB_FILE%"
 if ERRORLEVEL 1 (
     echo ERROR: Cscope executable returned non-zero code. >> %LOG_FILE%

--- a/plat/win32/update_scopedb.cmd
+++ b/plat/win32/update_scopedb.cmd
@@ -60,7 +60,7 @@ echo locked > "%DB_FILE%.lock"
 echo Running cscope >> %LOG_FILE%
 if NOT ["%FILE_LIST_CMD%"]==[""] (
     if ["%PROJECT_ROOT%"]==["."] (
-        call %FILE_LIST_CMD% > %DB_FILE%.files
+        for /F "usebackq delims=" %%F in (`%FILE_LIST_CMD%`) do @echo "%%F">%DB_FILE%.files
     ) else (
         rem Potentially useful:
         rem http://stackoverflow.com/questions/9749071/cmd-iterate-stdin-piped-from-another-command


### PR DESCRIPTION
Fix #173.

The following two commands are equivalent:
- ``%FILE_LIST_CMD% | for /F "usebackq delims=" %%F in (`findstr "."`) do ...``
- ``for /F "usebackq delims=" %%F in (`%FILE_LIST_CMD%`) do ...``

The line of `@echo %PROJECT_ROOT%\%%F > %DB_FILE%.files` should be fixed to `@echo "%PROJECT_ROOT%\%%F">%DB_FILE%.files` because:
- there can be file or directory names containing spaces
- `@echo something > file` makes `file` to contain trailing spaces on each line

There are no `%TAGS_FILE%` in `update_scopedb.cmd`, so I replaced `%TAGS_FILE%.files` with `%TAGS_FILE%.files`.

Also I changed `cscope -R` to use `%DBFILE%.files` which is generated by `dir /S /B /A-D .`, because `cscope -R` still needs input files. For the `dir` command,
- /S: lists specified directory and all subdirectories
- /B: displays a bare list of directories and files
- /A-D: displays all except directories

Also there is a [document](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/dir) of dir command.