### PR TITLE
Exclude cscope from default file list command

### DIFF
--- a/plat/unix/update_scopedb.sh
+++ b/plat/unix/update_scopedb.sh
@@ -70,7 +70,7 @@ if [ -n "${FILE_LIST_CMD}" ]; then
         done > "${DB_FILE}.files"
     fi
 else
-    find . -type f > "${DB_FILE}.files"
+    find . -type f ! -name ${DB_FILE} > "${DB_FILE}.files"
 fi
 CSCOPE_ARGS="${CSCOPE_ARGS} -i ${DB_FILE}.files"
 


### PR DESCRIPTION
With default setup gutentags generate file list for cscope using simple
`find -type f` command in update_scopedb.sh. Subsequent invocations of
this script causes unbounded growth of cscope database because cscope
indexes itself every time.

This change excludes cscope database file from default file list command
for cscope database generation so it will work properly by default.

Another option is to use custom file list command like `ag -l` that will
generate files known to source control, that is without cscope database
file.