### PR TITLE
Support generating an inverted index of cscope

### DIFF
--- a/autoload/gutentags/cscope.vim
+++ b/autoload/gutentags/cscope.vim
@@ -19,6 +19,10 @@ if !exists('g:gutentags_auto_add_cscope')
     let g:gutentags_auto_add_cscope = 1
 endif
 
+if !exists('g:gutentags_cscope_build_inverted_index')
+    let g:gutentags_cscope_build_inverted_index = 0
+endif
+
 " }}}
 
 " Gutentags Module Interface {{{
@@ -49,6 +53,9 @@ function! gutentags#cscope#generate(proj_dir, tags_file, gen_opts) abort
         \ gutentags#get_project_file_list_cmd(a:proj_dir)
     if !empty(l:file_list_cmd)
         let l:cmd += ['-L', '"' . l:file_list_cmd . '"']
+    endif
+    if g:gutentags_cscope_build_inverted_index
+        let l:cmd += ['-I']
     endif
     let l:cmd = gutentags#make_args(l:cmd)
 

--- a/doc/gutentags.txt
+++ b/doc/gutentags.txt
@@ -628,6 +628,14 @@ g:gutentags_cscope_executable
                         to use to generate the code database.
                         Defaults to `"cscope"`.
 
+                                                *gutentags_scopefile*
+g:gutentags_scopefile
+                        Specifies the name of the scope file to create. This
+                        will be appended to the project's root. See
+                        |gutentags_project_root| for how Gutentags locates the
+                        project.
+                        Defaults to `"cscope.out"`.
+
                                                 *gutentags_auto_add_cscope*
 g:gutentags_auto_add_cscope
                         If set to 1, Gutentags will automatically add the

--- a/doc/gutentags.txt
+++ b/doc/gutentags.txt
@@ -643,6 +643,12 @@ g:gutentags_auto_add_cscope
                         (see |:cscope|).
                         Defaults to 1.
 
+                                                *gutentags_cscope_build_inverted_index*
+g:gutentags_cscope_build_inverted_index
+                        If set to 1, Gutentags will make `cscope` build an
+                        inverted index.
+                        Defaults to 0.
+
 
 The following settings are valid for the `gtags_cscope` module.
 

--- a/plat/unix/update_scopedb.sh
+++ b/plat/unix/update_scopedb.sh
@@ -8,6 +8,7 @@ CSCOPE_ARGS=
 DB_FILE=cscope.out
 PROJECT_ROOT=
 FILE_LIST_CMD=
+BUILD_INVERTED_INDEX=0
 
 ShowUsage() {
     echo "Usage:"
@@ -17,11 +18,12 @@ ShowUsage() {
     echo "    -f [file=cscope.out]: The path to the ctags file to update"
     echo "    -p [dir=]:            The path to the project root"
     echo "    -L [cmd=]:            The file list command to run"
+    echo "    -I:                   Builds an inverted index"
     echo ""
 }
 
 
-while getopts "h?e:f:p:L:" opt; do
+while getopts "h?e:f:p:L:I" opt; do
     case $opt in
         h|\?)
             ShowUsage
@@ -39,6 +41,9 @@ while getopts "h?e:f:p:L:" opt; do
         L)
             FILE_LIST_CMD=$OPTARG
             ;;
+        I)
+            BUILD_INVERTED_INDEX=1
+            ;;
     esac
 done
 
@@ -53,7 +58,14 @@ echo "Locking cscope DB file..."
 echo $$ > "$DB_FILE.lock"
 
 # Remove lock and temp file if script is stopped unexpectedly.
-trap 'rm -f "$DB_FILE.lock" "$DB_FILE.files" "$DB_FILE.temp"' INT QUIT TERM EXIT
+CleanUp() {
+    rm -f "$DB_FILE.lock" "$DB_FILE.files" "$DB_FILE.temp"
+    if [ "$BUILD_INVERTED_INDEX" -eq 1 ]; then
+        rm -f "$DB_FILE.temp.in" "$DB_FILE.temp.po"
+    fi
+}
+
+trap CleanUp INT QUIT TERM EXIT
 
 PREVIOUS_DIR=$(pwd)
 if [ -d "$PROJECT_ROOT" ]; then
@@ -74,6 +86,10 @@ else
 fi
 CSCOPE_ARGS="${CSCOPE_ARGS} -i ${DB_FILE}.files"
 
+if [ "$BUILD_INVERTED_INDEX" -eq 1 ]; then
+    CSCOPE_ARGS="$CSCOPE_ARGS -q"
+fi
+
 echo "Running cscope"
 echo "$CSCOPE_EXE $CSCOPE_ARGS -b -k -f \"$DB_FILE.temp\""
 "$CSCOPE_EXE" $CSCOPE_ARGS -v -b -k -f "$DB_FILE.temp"
@@ -83,6 +99,12 @@ if [ -d "$PROJECT_ROOT" ]; then
 fi
 
 echo "Replacing cscope DB file"
+if [ "$BUILD_INVERTED_INDEX" -eq 1 ]; then
+    echo "mv -f \"$DB_FILE.temp.in\" \"$DB_FILE.in\""
+    mv -f "$DB_FILE.temp.in" "$DB_FILE.in"
+    echo "mv -f \"$DB_FILE.temp.po\" \"$DB_FILE.po\""
+    mv -f "$DB_FILE.temp.po" "$DB_FILE.po"
+fi
 echo "mv -f \"$DB_FILE.temp\" \"$DB_FILE\""
 mv -f "$DB_FILE.temp" "$DB_FILE"
 

--- a/plat/win32/update_scopedb.cmd
+++ b/plat/win32/update_scopedb.cmd
@@ -10,6 +10,7 @@ set CSCOPE_ARGS=
 set DB_FILE=cscope.out
 set FILE_LIST_CMD=
 set LOG_FILE=
+set BUILD_INVERTED_INDEX=0
 
 :ParseArgs
 if [%1]==[] goto :DoneParseArgs
@@ -36,6 +37,10 @@ if [%1]==[-L] (
 if [%1]==[-l] (
     set LOG_FILE=%~2
     shift
+    goto :LoopParseArgs
+)
+if [%1]==[-I] (
+    set BUILD_INVERTED_INDEX=1
     goto :LoopParseArgs
 )
 echo Invalid Argument: %1
@@ -70,6 +75,9 @@ if NOT ["%FILE_LIST_CMD%"]==[""] (
 ) ELSE (
     set CSCOPE_ARGS=%CSCOPE_ARGS% -R
 )
+if ["%BUILD_INVERTED_INDEX%"]==["1"] (
+    set CSCOPE_ARGS=%CSCOPE_ARGS% -q
+)
 "%CSCOPE_EXE%" %CSCOPE_ARGS% -b -k -f "%DB_FILE%"
 if ERRORLEVEL 1 (
     echo ERROR: Cscope executable returned non-zero code. >> %LOG_FILE%
@@ -99,5 +107,6 @@ echo    -f [file=cscope.out]:        The path to the database file to create
 echo    -p [dir=]:                   The path to the project root
 echo    -L [cmd=]:                   The file list command to run
 echo    -l [log=]:                   The log file to output to
+echo    -I:                          Builds an inverted index
 echo.
 

--- a/plat/win32/update_scopedb.cmd
+++ b/plat/win32/update_scopedb.cmd
@@ -94,10 +94,10 @@ rem ==========================================
 echo Usage:
 echo    %~n0 ^<options^>
 echo.
-echo    -e [exe=cscope]:     The cscope executable to run
-echo    -f [file=scope.out]: The path to the database file to create
-echo    -p [dir=]:           The path to the project root
-echo    -L [cmd=]:           The file list command to run
-echo    -l [log=]:           The log file to output to
+echo    -e [exe=cscope]:             The cscope executable to run
+echo    -f [file=cscope.out]:        The path to the database file to create
+echo    -p [dir=]:                   The path to the project root
+echo    -L [cmd=]:                   The file list command to run
+echo    -l [log=]:                   The log file to output to
 echo.
 


### PR DESCRIPTION
It's the `-q` option of cscope:
```
Usage: cscope [-bcCdehklLqRTuUvV] [-f file] [-F file] [-i file] [-I dir] [-s dir]
              [-p number] [-P path] [-[0-8] pattern] [source files]

-q            Build an inverted index for quick symbol searching.
```

But it needs additional handling because gutentags generates `cscope.out.temp` first, in UNIX. cscope will generate `cscope.out.temp.in` and `cscope.out.temp.po`, so after the generation, it requires renaming.

Please let me know if you want to change the name, `g:gutentags_cscope_build_inverted_index`.