### PR TITLE
Fix listing files with spaces for cscope

### DIFF
--- a/plat/unix/update_scopedb.sh
+++ b/plat/unix/update_scopedb.sh
@@ -62,15 +62,19 @@ fi
 
 if [ -n "${FILE_LIST_CMD}" ]; then
     if [ "${PROJECT_ROOT}" = "." ]; then
-        eval "$FILE_LIST_CMD" > "${DB_FILE}.files"
+        eval "$FILE_LIST_CMD" | while read -r l; do
+            echo "\"${l}\""
+        done > "${DB_FILE}.files"
     else
         # If using a tags cache directory, use absolute paths
         eval "$FILE_LIST_CMD" | while read -r l; do
-            echo "${PROJECT_ROOT%/}/${l}"
+            echo "\"${PROJECT_ROOT%/}/${l}\""
         done > "${DB_FILE}.files"
     fi
 else
-    find . -type f > "${DB_FILE}.files"
+    find . -type f | while read -r l; do
+        echo "\"${l}\""
+    done > "${DB_FILE}.files"
 fi
 CSCOPE_ARGS="${CSCOPE_ARGS} -i ${DB_FILE}.files"
 


### PR DESCRIPTION
The following is the scenario to reproduce the problem. The minimal `test.vimrc`:
``` vim
set nocompatible

call plug#begin()
Plug 'ludovicchabant/vim-gutentags'
call plug#end()

let g:gutentags_modules = ['ctags', 'cscope']
let g:gutentags_file_list_command = {
      \ 'markers': {
      \   '.git': 'git ls-files',
      \   '.hg': 'hg files'
      \ } }
let g:gutentags_trace = 1
```

``` sh
$ mkdir test && cd test
$ git init
$ cat >foo\ bar.c <<EOF
#include <stdio.h>

int main() {
  printf("test\n");
  return 0;
}
EOF
$ git add foo\ bar.c
$ vim -u test.vimrc foo\ bar.c
```

Then Vim gives me these:
```
gutentags: Scanning buffer 'foo bar.c' for gutentags setup...
gutentags: No specific project type.
gutentags: Setting gutentags for buffer 'foo bar.c'
gutentags: Generating missing tags file: /Users/yous/test/cscope.out
gutentags: Running: ['/Users/yous/.vim/plugged/vim-gutentags/plat/unix/update_scopedb.sh', '-e', 'cscope', '-p', '/Users/yous/test', '-f', '/Users/yous/test/cscope.out', '-L', 'git ls-files']
gutentags: In:      /Users/yous/test
gutentags: Generating tags file: /Users/yous/test/tags
gutentags: Wildignore options file is up to date.
gutentags: Running: ['/Users/yous/.vim/plugged/vim-gutentags/plat/unix/update_tags.sh', '-e', 'ctags', '-t', 'tags', '-p', '.', '-L', 'git ls-files', '-l', 'tags.log']
gutentags: In:      /Users/yous/test
Press ENTER or type command to continue
gutentags: [job output]: 'Locking cscope DB file...'
gutentags: [job output]: 'Locking tags file...'
gutentags: [job output]: 'Running file list command'
gutentags: [job output]: 'eval git ls-files > "tags.files"'
gutentags: [job output]: 'Running ctags on whole project'
gutentags: [job output]: 'ctags -f "tags.temp"  -L tags.files'
gutentags: [job output]: 'Running cscope'
gutentags: [job output]: 'cscope  -i /Users/yous/test/cscope.out.files -b -k -f "/Users/yous/test/cscope.out.temp"'
gutentags: [job output]: 'cscope: cannot find file /Users/yous/test/foo'
gutentags: [job output]: 'cscope: cannot find file bar.c'
gutentags: [job output]: 'cscope: no source files found'
gutentags: Finished cscope job.
gutentags: gutentags: cscope job failed, returned: 1
gutentags: [job output]: 'Replacing tags file'
gutentags: [job output]: 'mv -f "tags.temp" "tags"'
gutentags: [job output]: 'Unlocking tags file...'
gutentags: [job output]: 'Done.'
gutentags: Finished ctags job.
```

Note that cscope tries to find `foo` and `bar.c`. The filename should be formatted like `"foo bar.c"` so that cscope recognizes it properly. For Windows, #220 will handle this properly.