### PR TITLE
PyCscope support

### DIFF
--- a/autoload/gutentags/pycscope.vim
+++ b/autoload/gutentags/pycscope.vim
@@ -1,0 +1,86 @@
+" Pycscope module for Gutentags
+
+if !has('cscope')
+    throw "Can't enable the pycscope module for Gutentags, this Vim has ".
+                \"no support for cscope files."
+endif
+
+" Global Options {{{
+
+if !exists('g:gutentags_pycscope_executable')
+    let g:gutentags_pycscope_executable = 'pycscope'
+endif
+
+if !exists('g:gutentags_pyscopefile')
+    let g:gutentags_pyscopefile = 'pycscope.out'
+endif
+
+if !exists('g:gutentags_auto_add_pycscope')
+    let g:gutentags_auto_add_pycscope = 1
+endif
+
+" }}}
+
+" Gutentags Module Interface {{{
+
+let s:runner_exe = gutentags#get_plat_file('update_pyscopedb')
+let s:unix_redir = (&shellredir =~# '%s') ? &shellredir : &shellredir . ' %s'
+let s:added_dbs = []
+
+function! gutentags#pycscope#init(project_root) abort
+    let l:dbfile_path = gutentags#get_cachefile(
+                \a:project_root, g:gutentags_pyscopefile)
+    let b:gutentags_files['pycscope'] = l:dbfile_path
+
+    if g:gutentags_auto_add_pycscope && filereadable(l:dbfile_path)
+        if index(s:added_dbs, l:dbfile_path) < 0
+            call add(s:added_dbs, l:dbfile_path)
+            silent! execute 'cs add ' . fnameescape(l:dbfile_path)
+        endif
+    endif
+endfunction
+
+function! gutentags#pycscope#generate(proj_dir, tags_file, gen_opts) abort
+    let l:cmd = [s:runner_exe]
+    let l:cmd += ['-e', g:gutentags_pycscope_executable]
+    let l:cmd += ['-p', a:proj_dir]
+    let l:cmd += ['-f', a:tags_file]
+    let l:file_list_cmd =
+        \ gutentags#get_project_file_list_cmd(a:proj_dir)
+    if !empty(l:file_list_cmd)
+        let l:cmd += ['-L', '"' . l:file_list_cmd . '"']
+    endif
+    let l:cmd = gutentags#make_args(l:cmd)
+
+    call gutentags#trace("Running: " . string(l:cmd))
+    call gutentags#trace("In:      " . getcwd())
+    if !g:gutentags_fake
+		let l:job_opts = gutentags#build_default_job_options('pycscope')
+        let l:job = gutentags#start_job(l:cmd, l:job_opts)
+        call gutentags#add_job('pycscope', a:tags_file, l:job)
+    else
+        call gutentags#trace("(fake... not actually running)")
+    endif
+endfunction
+
+function! gutentags#pycscope#on_job_exit(job, exit_val) abort
+    let l:job_idx = gutentags#find_job_index_by_data('pycscope', a:job)
+    let l:dbfile_path = gutentags#get_job_tags_file('pycscope', l:job_idx)
+    call gutentags#remove_job('pycscope', l:job_idx)
+
+    if a:exit_val == 0
+        if index(s:added_dbs, l:dbfile_path) < 0
+            call add(s:added_dbs, l:dbfile_path)
+            silent! execute 'cs add ' . fnameescape(l:dbfile_path)
+        else
+            silent! execute 'cs reset'
+        endif
+    else
+        call gutentags#warning(
+                    \"gutentags: pycscope job failed, returned: ".
+                    \string(a:exit_val))
+    endif
+endfunction
+
+" }}}
+

--- a/doc/gutentags.txt
+++ b/doc/gutentags.txt
@@ -314,6 +314,9 @@ g:gutentags_modules
                         - `cscope`: generates a code database file using
                           `cscope`.
 
+                        - `pycscope`: generates a code database file using
+                          `pycscope`.
+
                         - `gtags_cscope`: same as `cscope` but uses GNU's
                           `gtags` executable and database.
 
@@ -636,6 +639,22 @@ g:gutentags_auto_add_cscope
                         Defaults to 1.
 
 
+The following settings are valid for the `pycscope` module.
+
+                                                *gutentags_pycscope_executable*
+g:gutentags_pycscope_executable
+                        Specifies the name or path of the `pycscope` executable
+                        to use to generate the code database.
+                        Defaults to `"pycscope"`.
+
+                                                *gutentags_auto_add_pycscope*
+g:gutentags_auto_add_pycscope
+                        If set to 1, Gutentags will automatically add the
+                        generated code database to Vim by running `:cs add`
+                        (see |:pycscope|).
+                        Defaults to 1.
+
+
 The following settings are valid for the `gtags_cscope` module.
 
                                                 *gutentags_gtags_executable*
@@ -658,7 +677,8 @@ g:gutentags_auto_add_gtags_cscope
                         (see |:cscope|).
                         Defaults to 1.
 
-People using `cscope` or `gtags_cscope` across multiple projects in the same
+
+People using `cscope`, `pycscope` or `gtags_cscope` across multiple projects in the same
 Vim instance might be interested in the `gutentags_plus` plugin, which handles
 switching databases automatically before performing a query. 
 See https://github.com/skywind3000/gutentags_plus.

--- a/plat/unix/update_pyscopedb.sh
+++ b/plat/unix/update_pyscopedb.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+
+set -e
+
+PROG_NAME=$0
+PYCSCOPE_EXE=pycscope
+PYCSCOPE_ARGS=
+DB_FILE=pycscope.out
+# Note that we keep the same name
+PROJECT_ROOT=
+FILE_LIST_CMD=
+
+ShowUsage() {
+    echo "Usage:"
+    echo "    $PROG_NAME <options>"
+    echo ""
+    echo "    -e [exe=pycscope]:      The pycscope executable to run"
+    echo "    -f [file=pycscope.out]: The path to the ctags file to update"
+    echo "    -p [dir=]:            The path to the project root"
+    echo "    -L [cmd=]:            The file list command to run"
+    echo ""
+}
+
+
+while getopts "h?e:f:p:L:" opt; do
+    case $opt in
+        h|\?)
+            ShowUsage
+            exit 0
+            ;;
+        e)
+            PYCSCOPE_EXE=$OPTARG
+            ;;
+        f)
+            DB_FILE=$OPTARG
+            ;;
+        p)
+            PROJECT_ROOT=$OPTARG
+            ;;
+        L)
+            FILE_LIST_CMD=$OPTARG
+            ;;
+    esac
+done
+
+shift $((OPTIND - 1))
+
+if [ "$1" != "" ]; then
+    echo "Invalid Argument: $1"
+    exit 1
+fi
+
+echo "Locking pycscope DB file..."
+echo $$ > "$DB_FILE.lock"
+
+# Remove lock and temp file if script is stopped unexpectedly.
+trap 'rm -f "$DB_FILE.lock" "$DB_FILE.files" "$DB_FILE.temp"' INT QUIT TERM EXIT
+
+PREVIOUS_DIR=$(pwd)
+if [ -d "$PROJECT_ROOT" ]; then
+    cd "$PROJECT_ROOT"
+fi
+
+if [ -n "${FILE_LIST_CMD}" ]; then
+    if [ "${PROJECT_ROOT}" = "." ]; then
+        eval "$FILE_LIST_CMD" > "${DB_FILE}.files"
+    else
+        # If using a tags cache directory, use absolute paths
+        eval "$FILE_LIST_CMD" | while read -r l; do
+            echo "${PROJECT_ROOT%/}/${l}"
+        done > "${DB_FILE}.files"
+    fi
+else
+    find . -type f > "${DB_FILE}.files"
+fi
+PYCSCOPE_ARGS="${PYCSCOPE_ARGS} -i ${DB_FILE}.files"
+
+echo "Running pycscope"
+echo "$PYCSCOPE_EXE -f \"$DB_FILE.temp\" "$PYCSCOPE_ARGS
+"$PYCSCOPE_EXE" -f "$DB_FILE.temp" $PYCSCOPE_ARGS
+
+if [ -d "$PROJECT_ROOT" ]; then
+    cd "$PREVIOUS_DIR"
+fi
+
+echo "Replacing pycscope DB file"
+echo "mv -f \"$DB_FILE.temp\" \"$DB_FILE\""
+mv -f "$DB_FILE.temp" "$DB_FILE"
+
+echo "Unlocking pycscope DB file..."
+rm -f "$DB_FILE.lock"
+
+echo "Done."


### PR DESCRIPTION
I hacked together this, there probably should be some smarter handling of when to load `pycscope` vs
`cscope`. However this could be left to the user to define their own autocmds.

Should close #218

*Sidenote*  using the `aur` package for pycscope didn't work for me so I used
https://github.com/lonetwin/pycscope fork.