### PR TITLE
Avoid duplicate tags when updating files

### DIFF
--- a/autoload/gutentags/ctags.vim
+++ b/autoload/gutentags/ctags.vim
@@ -112,9 +112,13 @@ function! gutentags#ctags#generate(proj_dir, tags_file, gen_opts) abort
     if l:write_mode == 0 && l:tags_file_exists
         let l:cur_file_path = expand('%:p')
         if empty(g:gutentags_cache_dir) && l:tags_file_is_local
+            let l:alt_file_path = l:cur_file_path
             let l:cur_file_path = fnamemodify(l:cur_file_path, ':.')
+        else
+            let l:alt_file_path = fnamemodify(l:cur_file_path, ':.')
         endif
         let l:cmd += ['-s', '"' . l:cur_file_path . '"']
+        let l:cmd += ['-a', '"' . l:alt_file_path . '"']
     else
         let l:file_list_cmd = gutentags#get_project_file_list_cmd(l:actual_proj_dir)
         if !empty(l:file_list_cmd)

--- a/plat/unix/update_tags.sh
+++ b/plat/unix/update_tags.sh
@@ -11,6 +11,7 @@ LOG_FILE=
 FILE_LIST_CMD=
 FILE_LIST_CMD_IS_ABSOLUTE=0
 UPDATED_SOURCE=
+ALT_UPDATED_SOURCE=
 POST_PROCESS_CMD=
 PAUSE_BEFORE_EXIT=0
 
@@ -27,6 +28,8 @@ ShowUsage() {
     echo "    -A:             Specifies that the file list command returns "
     echo "                    absolute paths"
     echo "    -s [file=]:     The path to the source file that needs updating"
+    echo "    -a [file=]:     Alternative path to the source file that needs"
+    echo "                    to be removed from the tags file"
     echo "    -x [pattern=]:  A pattern of files to exclude"
     echo "    -o [options=]:  An options file to read additional options from"
     echo "    -O [params=]:   Parameters to pass to ctags"
@@ -36,7 +39,7 @@ ShowUsage() {
 }
 
 
-while getopts "h?e:x:t:p:l:L:s:o:O:P:cA" opt; do
+while getopts "h?e:x:t:p:l:L:s:a:o:O:P:cA" opt; do
     case $opt in
         h|\?)
             ShowUsage
@@ -65,6 +68,9 @@ while getopts "h?e:x:t:p:l:L:s:o:O:P:cA" opt; do
             ;;
         s)
             UPDATED_SOURCE=$OPTARG
+            ;;
+        a)
+            ALT_UPDATED_SOURCE=$OPTARG
             ;;
         c)
             PAUSE_BEFORE_EXIT=1
@@ -98,8 +104,14 @@ INDEX_WHOLE_PROJECT=1
 if [ -f "$TAGS_FILE" ]; then
     if [ "$UPDATED_SOURCE" != "" ]; then
         echo "Removing references to: $UPDATED_SOURCE"
+        if [ "$ALT_UPDATED_SOURCE" != "" ]; then
+            echo "Removing references to: $ALT_UPDATED_SOURCE"
+            regex="($UPDATED_SOURCE|$ALT_UPDATED_SOURCE)"
+        else
+            regex=$UPDATED_SOURCE
+        fi
         tab="	"
-        cmd="grep --text -Ev '^[^$tab]+$tab$UPDATED_SOURCE$tab' '$TAGS_FILE' > '$TAGS_FILE.temp'"
+        cmd="grep --text -Ev '^[^$tab]+$tab$regex$tab' '$TAGS_FILE' > '$TAGS_FILE.temp'"
         echo "$cmd"
         eval "$cmd" || true
         INDEX_WHOLE_PROJECT=0

--- a/plat/win32/update_tags.cmd
+++ b/plat/win32/update_tags.cmd
@@ -12,6 +12,7 @@ set PROJECT_ROOT=
 set FILE_LIST_CMD=
 set FILE_LIST_CMD_IS_ABSOLUTE=0
 set UPDATED_SOURCE=
+set ALT_UPDATED_SOURCE=
 set POST_PROCESS_CMD=
 set PAUSE_BEFORE_EXIT=0
 set LOG_FILE=
@@ -49,6 +50,11 @@ if [%1]==[-A] (
 )
 if [%1]==[-s] (
     set UPDATED_SOURCE=%~2
+    shift
+    goto :LoopParseArgs
+)
+if [%1]==[-a] (
+    set ALT_UPDATED_SOURCE=%~2
     shift
     goto :LoopParseArgs
 )
@@ -101,6 +107,7 @@ if exist "%TAGS_FILE%" (
         echo Removing references to: %UPDATED_SOURCE% >> %LOG_FILE%
         echo findstr /V /C:"%UPDATED_SOURCE%" "%TAGS_FILE%" ^> "%TAGS_FILE%.temp" >> %LOG_FILE%
         findstr /V /C:"%UPDATED_SOURCE%" "%TAGS_FILE%" > "%TAGS_FILE%.temp"
+        rem XXX should also remove %ALT_UPDATED_SOURCE%
         set CTAGS_ARGS=%CTAGS_ARGS% --append "%UPDATED_SOURCE%"
         set INDEX_WHOLE_PROJECT=0
     )


### PR DESCRIPTION
Since we cannot know in every case whether the tags file contains absolute or relative pathnames, let's remove old tags that use either version of the pathname.

Fixes #231 for Unix.  Unfortunately my Windows scripting skills are insufficient to implement the full logic in  plat/win32/update_tags.cmd, but at least I updated the argument parsing loop so it won't fail if it sees the new -a argument.