### PR TITLE
Check if there are files to generate cscope DB

### DIFF
--- a/plat/unix/update_scopedb.sh
+++ b/plat/unix/update_scopedb.sh
@@ -88,6 +88,12 @@ else
         echo "\"${l}\""
     done > "${DB_FILE}.files"
 fi
+
+if [ ! -s "${DB_FILE}.files" ]; then
+    echo "There is no files to generate cscope DB"
+    exit
+fi
+
 CSCOPE_ARGS="${CSCOPE_ARGS} -i ${DB_FILE}.files"
 
 if [ "$BUILD_INVERTED_INDEX" -eq 1 ]; then

--- a/plat/win32/update_scopedb.cmd
+++ b/plat/win32/update_scopedb.cmd
@@ -74,6 +74,14 @@ if NOT ["%FILE_LIST_CMD%"]==[""] (
 ) ELSE (
     for /F "usebackq delims=" %%F in (`dir /S /B /A-D .`) do @echo "%%F">%DB_FILE%.files
 )
+
+set FILESIZE=0
+for /F %%F in ("%DB_FILE%.files") do set FILESIZE=%%~zF
+if %FILESIZE% EQU 0 (
+    echo There is no files to generate cscope DB
+    goto :EOF
+)
+
 set CSCOPE_ARGS=%CSCOPE_ARGS% -i %DB_FILE%.files
 if ["%BUILD_INVERTED_INDEX%"]==["1"] (
     set CSCOPE_ARGS=%CSCOPE_ARGS% -q


### PR DESCRIPTION
Recently I've got the `gutentags: cscope job failed, returned: 1` message quite a lot, so I've dug into it. The main reason is the empty file list for cscope.

I use a custom file list command, something like `git ls-files '*.c' '*.h' '*.cpp' '*.hpp'`. When I open a Vim in a project doesn't have such files, the file list (`"${DB_FILE}.files"`) is empty, and cscope complains about it: `cscope: no source files found`.

I think this shouldn't be an error, so I added the checking logic to return early. Unfortunately, I didn't test on Windows, I would appreciate it if someone check this patch.