### PR TITLE
Double escape spaces when setting tags path

### DIFF
--- a/autoload/gutentags/ctags.vim
+++ b/autoload/gutentags/ctags.vim
@@ -53,7 +53,13 @@ function! gutentags#ctags#init(project_root) abort
 
     " Set the tags file for Vim to use.
     if g:gutentags_ctags_auto_set_tags
-        execute 'setlocal tags^=' . fnameescape(b:gutentags_files['ctags'])
+        if has('win32') || has('win64')
+            execute 'setlocal tags^=' . fnameescape(b:gutentags_files['ctags'])
+        else
+            " spaces must be literally escaped in tags path
+            let l:literal_space_escaped = substitute(fnameescape(b:gutentags_files['ctags']), '\ ', '\\\\ ', 'g')
+            execute 'setlocal tags^=' . l:literal_space_escaped
+        endif
     endif
 
     " Check if the ctags executable exists.


### PR DESCRIPTION
The tags variable need spaces in the path to be literally escaped in order to work.

### Repro Steps
Using macOS 10.14.6, vim 8.1.1517.

Create the the a project with a space in it's path
```bash
foo="folder space" && mkdir "$foo" && cd "$foo" &&\
git init && echo 'def foo(): return 0' > foo.py &&\
mkdir bar && cd bar && touch bar.py
``` 
The above command create:
```text
folder space/.git
folder space/foo.py
folder space/bar/bar.py
```
Set `folder space/bar/` as the current working directory, the open `bar.py` in `vim`

Without this patch, the command `:tag foo` complains that no tag files can be found:
```
E433: No tags file
E426: tag not found: foo
Press ENTER or type command to continue
```

With the patch,  the command `:tag foo` in `folder space/bar/bar.py` will jump to the `foo()` function in `folder space/foo.py`.

I've also tested this patch with project directory with more than one space it works as well.