### PR TITLE
Don't terminate jobs on exit

### DIFF
--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -603,7 +603,8 @@ if has('nvim')
                 \    ['gutentags#default_io_cb']),
                 \'on_stderr': function(
                 \    '<SID>nvim_job_out_wrapper',
-                \    ['gutentags#default_io_cb'])
+                \    ['gutentags#default_io_cb']),
+                \'detach': 1
                 \}
        return l:job_opts
     endfunction
@@ -618,7 +619,7 @@ else
                  \'exit_cb': 'gutentags#'.a:module.'#on_job_exit',
                  \'out_cb': 'gutentags#default_io_cb',
                  \'err_cb': 'gutentags#default_io_cb',
-                 \'stoponexit': 'term'
+                 \'stoponexit': ''
                  \}
         return l:job_opts
     endfunction


### PR DESCRIPTION
Terminating jobs on exit can lead to race conditions with `:x` on a
changed buffer. In that scenario, the job updating the tags file can be
prematurely terminated when vim exits.

This issue started happening for me after updating to neovim 0.4.2. Error message after executing `:x` on a changed file, with `let g:gutentags_trace=1`.
```
gutentags: [job output]: ['Locking tags file...', 'Removing references to: foo.py', 'grep --text -Ev ''^[^^I]+^Ifoo.py^I'' ''.tags'' > ''.tags.temp''', 'Running ctags on "foo.py"', 'ctags -f ".tags.temp"  --options=/Users/yukun/vim-gutentags/res/ctags_recursive.options --exclude=@/var/folders/dj/plng1rzs6910gyws3tchvbn00000gn/T/nvimFifjdn/1 --append "foo.py"', 'Replacing tags file', 'mv -f ".tags.temp" ".tags"', '']
gutentags: Finished ctags job.
gutentags: ctags job failed, returned: 141% 
```
I suspect it's due to some changes between neovim and 0.3.8 and 0.4.2 that changed the timing of events that lead to jobs being terminated earlier on exit than before. The error code indicates failure from being killed by a signal (https://neovim.io/doc/user/job_control.html#on_exit).
 