### PR TITLE
Improve compatibility with ctags like programs

### DIFF
--- a/plat/unix/update_tags.sh
+++ b/plat/unix/update_tags.sh
@@ -71,7 +71,7 @@ while getopts "h?e:x:t:p:l:L:s:o:O:P:cA" opt; do
             PAUSE_BEFORE_EXIT=1
             ;;
         o)
-            CTAGS_ARGS="$CTAGS_ARGS --options=$OPTARG"
+            CTAGS_ARGS="$CTAGS_ARGS $(tr '\n' ' ' < $OPTARG)"
             ;;
         O)
             CTAGS_ARGS="$CTAGS_ARGS $OPTARG"

--- a/res/ctags_recursive.options
+++ b/res/ctags_recursive.options
@@ -1,2 +1,2 @@
---recurse=yes
+--recurse
 


### PR DESCRIPTION
These changes are for improving using gutentags with other programs like `ctags`. Specifically when I was trying to use [`ctags-shim`](https://github.com/tkonolige/ctags-shim) and was getting the error `ctags job failed, returned: 1`.

I figured out it was due to the way gutentags was supplying arguments to the executable.

I have made the following changes that produce the desired behavior with `ctags-shim` while having the same behavior as before with `ctags`:
- In-lines arguments from options file instead of using `--options`
- For recursive just use `--recurse` not `--recurse=yes`

I intended to update `update_tags.cmd` too, but I do not know batch files very well and have no setup to test my changes with. So this PR working for Linux but not windows still needs a change.