### PR TITLE
Fix ctags quoted options in ctags command

### DIFF
--- a/plat/unix/update_tags.sh
+++ b/plat/unix/update_tags.sh
@@ -129,7 +129,7 @@ if [ $INDEX_WHOLE_PROJECT -eq 1 ]; then
 
     echo "Running ctags on whole project"
     echo "$CTAGS_EXE -f \"$TAGS_FILE.temp\" $CTAGS_ARGS \"$CTAGS_ARG_QUOTED_LAST\""
-    "$CTAGS_EXE" -f "$TAGS_FILE.temp" $CTAGS_ARGS "$CTAGS_QUOTED_OPTIONS" "$CTAGS_ARG_QUOTED_LAST"
+    "$CTAGS_EXE" -f "$TAGS_FILE.temp" $CTAGS_ARGS "$CTAGS_ARG_QUOTED_LAST" "$CTAGS_QUOTED_OPTIONS"
 else
     echo "Running ctags on \"$UPDATED_SOURCE\""
     echo "$CTAGS_EXE -f \"$TAGS_FILE.temp\" $CTAGS_ARGS --append \"$UPDATED_SOURCE\""


### PR DESCRIPTION
This is to fix a bug introduced from #258.

---

To reproduce the bug, you can set a custom file list command:

```
let g:gutentags_file_list_command = 'rg --files --color=never'
```

Gutentags is trying to run this command:

```
ctags -f tags.temp -L --options=/dev/null tags.files
```

Which gives us the error:

```
ctags: cannot open list file "--options=/dev/null"
```

---

The right command should be:

```
ctags -f tags.temp -L tags.files --options=/dev/null
```