### PR TITLE
escape the file name in a right way, and handle `tcd` in vim

### DIFF
--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -6,9 +6,9 @@ function! gutentags#chdir(path)
     if has('nvim')
         let chdir = haslocaldir() ? 'lcd' : haslocaldir(-1, 0) ? 'tcd' : 'cd'
     else
-        let chdir = haslocaldir() ? 'lcd' : 'cd'
+		let chdir = haslocaldir()? ((haslocaldir() == 1)? 'lcd':'tcd') : 'cd'
     endif
-    execute chdir a:path
+    execute chdir fnameescape(a:path)
 endfunction
 
 " Throw an exception message.

--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -6,7 +6,7 @@ function! gutentags#chdir(path)
     if has('nvim')
         let chdir = haslocaldir() ? 'lcd' : haslocaldir(-1, 0) ? 'tcd' : 'cd'
     else
-		let chdir = haslocaldir()? ((haslocaldir() == 1)? 'lcd':'tcd') : 'cd'
+        let chdir = haslocaldir()? ((haslocaldir() == 1)? 'lcd':'tcd') : 'cd'
     endif
     execute chdir fnameescape(a:path)
 endfunction


### PR DESCRIPTION
use `fnameescape` instead of substitute:

```
fnameescape({string})					*fnameescape()*
		Escape {string} for use as file name command argument.  All
		characters that have a special meaning, such as '%' and '|'
		are escaped with a backslash.
		For most systems the characters escaped are
		" \t\n*?[{`$\\%#'\"|!<".  For systems where a backslash
		appears in a filename, it depends on the value of 'isfname'.
		A leading '+' and '>' is also escaped (special after |:edit|
		and |:write|).  And a "-" by itself (special after |:cd|).
		Example: >
			:let fname = '+some str%nge|name'
			:exe "edit " . fnameescape(fname)
<		results in executing: >
			edit \+some\ str\%nge\|name
<
		Can also be used as a |method|: >
			GetName()->fnameescape()
```