### PR TITLE
Check for temp tags before moving to avoid error

### DIFF
--- a/plat/unix/update_tags.sh
+++ b/plat/unix/update_tags.sh
@@ -153,7 +153,9 @@ fi
 
 echo "Replacing tags file"
 echo "mv -f \"$TAGS_FILE.temp\" \"$TAGS_FILE\""
-mv -f "$TAGS_FILE.temp" "$TAGS_FILE"
+if [ -f "$TAGS_FILE.temp" ]; then
+    mv -f "$TAGS_FILE.temp" "$TAGS_FILE"
+fi
 
 echo "Unlocking tags file..."
 rm -f "$TAGS_FILE.lock"


### PR DESCRIPTION
I was getting the following error when working on non-code files in large repositories:
```
gutentags: [job stderr]: ['mv: cannot stat ''.tags.temp'': No such file or directory', '']
```
An easy fix is just to check that the file exists before invoking `mv`, which is included in this patch.

Thanks!