### PR TITLE
docs: use ripper-tags as example value

### DIFF
--- a/doc/gutentags.txt
+++ b/doc/gutentags.txt
@@ -574,7 +574,7 @@ g:gutentags_ctags_executable_{type}
                         information.
                         IMPORTANT: please see |gutentags-ctags-requirements|.
                         Example: >
-                         let g:gutentags_ctags_executable_ruby = 'foobar'
+                         let g:gutentags_ctags_executable_ruby = 'ripper-tags'
 <
 
                                                 *gutentags_ctags_tagfile*


### PR DESCRIPTION
Since the docs specifically provide an example for `ruby`s file type.

`ripper-tags` provide excellent support for `ruby`.
This update emphasizes that `ripper-tags` should be
used as executable on `ruby`'s filetype