### PR TITLE
Remove fnameescape call in chdir function

### DIFF
--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -8,7 +8,7 @@ function! gutentags#chdir(path)
     else
         let chdir = haslocaldir() ? ((haslocaldir() == 1) ? 'lcd' : 'tcd') : 'cd'
     endif
-    execute chdir fnameescape(a:path)
+    execute chdir a:path
 endfunction
 
 " Throw an exception message.


### PR DESCRIPTION
fnameescape is applied when calling gutentags#chdir when called again it can cause the addition of extra escape characters. Resolves issue #277.