### PR TITLE
gtags support gutentags_file_list_cmd

### DIFF
--- a/autoload/gutentags/gtags_cscope.vim
+++ b/autoload/gutentags/gtags_cscope.vim
@@ -31,6 +31,7 @@ endif
 
 " Gutentags Module Interface {{{
 
+let s:runner_exe = gutentags#get_plat_file('update_gtags')
 let s:added_db_files = {}
 
 function! s:add_db(db_file) abort
@@ -77,18 +78,25 @@ function! gutentags#gtags_cscope#init(project_root) abort
 endfunction
 
 function! gutentags#gtags_cscope#generate(proj_dir, tags_file, gen_opts) abort
-    " gtags doesn't honour GTAGSDBPATH and GTAGSROOT, so PWD and dbpath
-    " have to be set
-    let l:db_path = fnamemodify(a:tags_file, ':p:h')
+    let l:cmd = [s:runner_exe]
+    let l:cmd += ['-e', '"' . g:gutentags_gtags_executable . '"']
+
+    let l:file_list_cmd = gutentags#get_project_file_list_cmd(a:proj_dir)
+    if !empty(l:file_list_cmd)
+        let l:cmd += ['-L', '"' . l:file_list_cmd . '"']
+    endif
 
     let l:proj_options_file = a:proj_dir . '/' . g:gutentags_gtags_options_file
-
-    let l:cmd = ['"'.g:gutentags_gtags_executable.'"']
     if filereadable(l:proj_options_file)
         let l:proj_options = readfile(l:proj_options_file)
         let l:cmd += l:proj_options
     endif
+
+    " gtags doesn't honour GTAGSDBPATH and GTAGSROOT, so PWD and dbpath
+    " have to be set
+    let l:db_path = fnamemodify(a:tags_file, ':p:h')
     let l:cmd += ['--incremental', '"'.l:db_path.'"']
+
     let l:cmd = gutentags#make_args(l:cmd)
 
     call gutentags#trace("Running: " . string(l:cmd))

--- a/plat/unix/update_gtags.sh
+++ b/plat/unix/update_gtags.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -e
+
+PROG_NAME=$0
+GTAGS_EXE=gtags
+FILE_LIST_CMD=
+
+ShowUsage() {
+    echo "Usage:"
+    echo "    $PROG_NAME <options>"
+    echo ""
+    echo "    -e [exe=gtags]:       The gtags executable to run."
+    echo "    -L [cmd=]:            The file list command to run."
+    echo ""
+}
+
+while [[ $# -ne 0 ]]; do
+  case "$1" in
+    -h)
+      ShowUsage
+      exit 0
+      ;;
+    -e)
+      GTAGS_EXE=$2
+      shift 2
+      ;;
+    -L)
+      FILE_LIST_CMD=$2
+      shift 2
+      ;;
+    *)
+      GTAGS_ARGS="$GTAGS_ARGS $1"
+      shift
+      ;;
+  esac
+done
+
+if [ -n "$FILE_LIST_CMD" ]; then
+  CMD="$FILE_LIST_CMD | $GTAGS_EXE -f- $GTAGS_ARGS"
+else
+  CMD="$GTAGS_EXE $GTAGS_ARGS"
+fi
+
+echo "Running gtags:"
+echo "$CMD"
+eval "$CMD"
+echo "Done."


### PR DESCRIPTION
Added a wrapper bash script `update_gtags.sh`, just like `update_tags.sh` and `update_scopedb.sh`.
However, I'm not familiar with Windows, so I can't write the corresponding cmd scripts :(
e.g.
```
gutentags: Generating tags file: /home/user/.cache/gutentags/home-user-project/GTAGS
gutentags: Running: ['/home/user/.vim/pack/navigation/start/vim-gutentags/plat/unix/update_gtags.sh', '-e', 'gtags', '-L', 'rg --files', '--incremental', '/home/user/.cache/gutentags/home-user-project']
gutentags: In:      /home/user/project
gutentags:
gutentags: [job stdout]: 'Running gtags:'
gutentags: [job stdout]: 'rg --files | gtags -f-  --incremental /home/user/.cache/gutentags/home-user-project'
gutentags: [job stdout]: 'Done.'
gutentags: Finished gtags_cscope job.
```