### PR TITLE
feat: support gutentags_file_list_command on the gtags_cscope module

### DIFF
--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -13,7 +13,8 @@ endfunction
 function! gutentags#root()
     if !exists('b:gutentags_root')
         " change directory to the current file if the project root not found
-        call gutentags#chdir('%:p:h')
+        call gutentags#chdir(expand('%:p:h'))
+        return
     endif
 
     call gutentags#chdir(b:gutentags_root)
@@ -320,16 +321,16 @@ function! gutentags#setup_gutentags() abort
             let l:buf_dir = fnamemodify(resolve(expand('%:p', 1)), ':p:h')
         endif
         if !exists('b:gutentags_root')
-            let b:has_located = 0
+            let l:has_located = 0
             let b:gutentags_root = gutentags#get_project_root(l:buf_dir)
         else
-            let b:has_located = 1
+            let l:has_located = 1
         endif
 
         if !len(b:gutentags_root)
             call gutentags#trace("no valid project root.. no gutentags support.")
             " Let the user do something in the buffer directory.
-            if !b:has_located && g:gutentags_root_located_user_func != '' &&
+            if !l:has_located && g:gutentags_root_located_user_func != '' &&
                         \!call(g:gutentags_root_located_user_func, [l:buf_dir, 0])
                 call gutentags#trace("Ignoring '" . bufname('%') . "' because of " .
                             \"custom `root_located` user function.")
@@ -343,7 +344,7 @@ function! gutentags#setup_gutentags() abort
         if filereadable(b:gutentags_root . '/.notags')
             call gutentags#trace("'.notags' file found... no gutentags support.")
             " Let the user do something in the project root.
-            if !b:has_located && g:gutentags_root_located_user_func != '' &&
+            if !l:has_located && g:gutentags_root_located_user_func != '' &&
                         \!call(g:gutentags_root_located_user_func, [b:gutentags_root, 0])
                 call gutentags#trace("Ignoring '" . bufname('%') . "' because of " .
                             \"custom `root_located` user function.")
@@ -354,7 +355,7 @@ function! gutentags#setup_gutentags() abort
         endif
 
         " Let the user do something in the project root.
-        if !b:has_located && g:gutentags_root_located_user_func != '' &&
+        if !l:has_located && g:gutentags_root_located_user_func != '' &&
                     \!call(g:gutentags_root_located_user_func, [b:gutentags_root, 1])
             call gutentags#trace("Ignoring '" . bufname('%') . "' because of " .
                         \"custom `root_located` user function.")

--- a/autoload/gutentags/ctags.vim
+++ b/autoload/gutentags/ctags.vim
@@ -46,7 +46,7 @@ function! gutentags#ctags#init(project_root) abort
     " Check the old name for this option, too, before falling back to the
     " globally defined name.
     let l:tagfile = getbufvar("", 'gutentags_ctags_tagfile',
-                \getbufvar("", 'gutentags_tagfile', 
+                \getbufvar("", 'gutentags_tagfile',
                 \g:gutentags_ctags_tagfile))
     let b:gutentags_files['ctags'] = gutentags#get_cachefile(
                 \a:project_root, l:tagfile)
@@ -92,7 +92,7 @@ function! gutentags#ctags#generate(proj_dir, tags_file, gen_opts) abort
         endif
     endif
 
-    " Get a tags file path relative to the current directory, which 
+    " Get a tags file path relative to the current directory, which
     " happens to be the project root in this case.
     " Since the given tags file path is absolute, and since Vim won't
     " change the path if it is not inside the current directory, we
@@ -109,7 +109,7 @@ function! gutentags#ctags#generate(proj_dir, tags_file, gen_opts) abort
         "
         " Note that if we don't do this and pass a full path for the project
         " root, some `ctags` implementations like Exhuberant Ctags can get
-        " confused if the paths have spaces -- but not if you're *in* the root 
+        " confused if the paths have spaces -- but not if you're *in* the root
         " directory, for some reason... (which will be the case, we're running
         " the jobs from the project root).
         let l:actual_proj_dir = '.'
@@ -117,12 +117,12 @@ function! gutentags#ctags#generate(proj_dir, tags_file, gen_opts) abort
 
         let l:tags_file_dir = fnamemodify(l:actual_tags_file, ':h')
         if l:tags_file_dir != '.'
-            " Ok so now the tags file is stored in a subdirectory of the 
+            " Ok so now the tags file is stored in a subdirectory of the
             " project root, instead of at the root. This happens if, say,
             " someone set `gutentags_ctags_tagfile` to `.git/tags`, which
             " seems to be fairly popular.
             "
-            " By default, `ctags` writes paths relative to the current 
+            " By default, `ctags` writes paths relative to the current
             " directory (the project root) but in this case we need it to
             " be relative to the tags file (e.g. adding `../` in front of
             " everything if the tags file is `.git/tags`).
@@ -248,7 +248,7 @@ function! s:generate_wildignore_options() abort
         if empty(g:gutentags_cache_dir)
             let s:wildignores_options_path = tempname()
         else
-            let s:wildignores_options_path = 
+            let s:wildignores_options_path =
                         \gutentags#stripslash(g:gutentags_cache_dir).
                         \'/_wildignore.options'
         endif

--- a/autoload/gutentags/gtags_cscope.vim
+++ b/autoload/gutentags/gtags_cscope.vim
@@ -69,7 +69,7 @@ function! gutentags#gtags_cscope#init(project_root) abort
     let $GTAGSDBPATH = l:db_path
     let $GTAGSROOT = a:project_root
 
-    if g:gutentags_auto_add_gtags_cscope && 
+    if g:gutentags_auto_add_gtags_cscope &&
                 \!has_key(s:added_db_files, l:db_file)
         let s:added_db_files[l:db_file] = 0
         call s:add_db(l:db_file)
@@ -89,6 +89,19 @@ function! gutentags#gtags_cscope#generate(proj_dir, tags_file, gen_opts) abort
         let l:cmd += l:proj_options
     endif
     let l:cmd += ['--incremental', '"'.l:db_path.'"']
+
+    let l:file_list_cmd = gutentags#get_project_file_list_cmd(a:proj_dir)
+    if !empty(l:file_list_cmd)
+        " Pipe `file_list_cmd` to the stdin of gtags-cscope
+        let l:cmd += ['-f', '-']
+        let l:gtags_cmd = l:file_list_cmd . ' | ' . join(l:cmd, ' ')
+        if has('win32') || has('win64')
+            let l:cmd = ['PowerShell', '-Command', l:gtags_cmd]
+        else
+            let l:cmd = ['sh', '-c', l:gtags_cmd]
+        endif
+    endif
+
     let l:cmd = gutentags#make_args(l:cmd)
 
     call gutentags#trace("Running: " . string(l:cmd))

--- a/doc/gutentags.txt
+++ b/doc/gutentags.txt
@@ -97,7 +97,7 @@ I set for myself with Gutentags:
   the tag file, otherwise you will still "see" tags for deleted or renamed
   classes and functions.
 * Automatically create the tag file: you open something from a freshly forked
-  project, it should start indexing it automatically, just like in Sublime Text 
+  project, it should start indexing it automatically, just like in Sublime Text
   or Visual Studio or any other IDE.
 
 
@@ -123,7 +123,7 @@ Gutentags finds a valid project root, it will prepend the tag file's path to
 sure Vim will use that file first.
 
 If a file managed by Gutentags is opened and no tag file already exists,
-Gutentags will start generating it right away in the background, unless 
+Gutentags will start generating it right away in the background, unless
 |gutentags_generate_on_missing| is set to 0. If you have a large project, you
 may want to know when Gutentags is generating tags: see
 |gutentags-status-line| to display an indicator in your status line.
@@ -327,7 +327,7 @@ g:gutentags_project_root
                         in the current file's directory and its parent
                         directories. If it finds any of those markers,
                         Gutentags will be enabled for the project, and a tags
-                        file named after |gutentags_ctags_tagfile| will be 
+                        file named after |gutentags_ctags_tagfile| will be
                         created at the project root.
                         Defaults to `[]` (an empty |List|).
                         A list of default markers will be appended to the
@@ -463,7 +463,7 @@ g:gutentags_resolve_symlinks
                         maybe not what you want if the symlink itself is
                         part of the project.
                         Defaults to 0.
-                        
+
                                             *gutentags_init_user_func*
 g:gutentags_init_user_func
                         When set to a non-empty string, it is expected to be
@@ -474,12 +474,29 @@ g:gutentags_init_user_func
 
                         You can use this to manually set buffer-local
                         settings:
-                        
+
                         * `b:gutentags_ctags_tagfile` (see |gutentags_ctags_tagfile|).
 
-                        This setting was previously called 
+                        This setting was previously called
                         `gutentags_enabled_user_func`. The old setting is
                         still used as a fallback.
+
+                        Defaults to "".
+
+                                            *g:gutentags_root_located_user_func*
+g:gutentags_root_located_user_func
+                        When set to a non-empty string, it is expected to be
+                        the name of a function that will be called when the
+                        project root has been located. The function gets passed
+                        the path of project root and a boolean value indicates
+                        whether this file will be enabled by Gutentags, and if
+                        it returns 0, Gutentags won't be enabled for that file.
+
+                        You can use this to manually set buffer-local
+                        settings or loading some custom configurations
+                        in the project root:
+
+                        * `b:gutentags_ctags_tagfile` (see |gutentags_ctags_tagfile|).
 
                         Defaults to "".
 
@@ -596,7 +613,7 @@ g:gutentags_ctags_exclude
                                                 *gutentags_ctags_exclude_wildignore*
 g:gutentags_ctags_exclude_wildignore
                         When 1, Gutentags will automatically pass your
-                        'wildignore' file patterns to the 
+                        'wildignore' file patterns to the
                         |gutentags_ctags_executable| so that they are ignored.
                         Set also |gutentags_ctags_exclude| to pass custom
                         patterns.

--- a/doc/gutentags.txt
+++ b/doc/gutentags.txt
@@ -334,6 +334,25 @@ g:gutentags_project_root
                         user-defined ones unless
                         |gutentags_add_default_project_roots| is set to 0.
 
+                                                *gutentags_project_config*
+g:gutentags_project_config
+                        A name of project-level vimrc configuration file. When
+                        a project root has been located, Gutentags will use
+                        this name to find the configuration file in the
+                        project root directory and |source| it if exists.
+                        This is useful if you want to define some plugin
+                        options for a project (e.g., |gutentags_file_list_command|).
+
+                        Note: A project configuration file is loaded after the
+                        project-root locating is completed.
+                        Note: For security reasons, a project configuration is
+                        sourced in |sandbox| unless
+                        |gutentags_project_config_in_sandbox| is set to 0.
+                        Note: This value will be appended to the default root
+                        markers if the value is not an empty |String|.
+
+                        Defaults to `'.gufig'`.
+
                                             *gutentags_add_default_project_roots*
 g:gutentags_add_default_project_roots
                         Defines whether Gutentags should always define some
@@ -342,6 +361,10 @@ g:gutentags_add_default_project_roots
                         when Gutentags searches for a project root.
                         The default markers are:
                         `['.git', '.hg', '.svn', '.bzr', '_darcs', '_darcs', '_FOSSIL_', '.fslckout']`
+
+                        Note: |gutentags_project_config| will be appended to
+                        the default markers if its value is not an empty
+                        |String|.
 
                                             *gutentags_add_ctrlp_root_markers*
 g:gutentags_add_ctrlp_root_markers
@@ -483,7 +506,7 @@ g:gutentags_init_user_func
 
                         Defaults to "".
 
-                                            *g:gutentags_root_located_user_func*
+                                            *gutentags_root_located_user_func*
 g:gutentags_root_located_user_func
                         When set to a non-empty string, it is expected to be
                         the name of a function that will be called when the
@@ -499,6 +522,13 @@ g:gutentags_root_located_user_func
                         * `b:gutentags_ctags_tagfile` (see |gutentags_ctags_tagfile|).
 
                         Defaults to "".
+
+                                            *gutentags_project_config_in_sandbox*
+g:gutentags_project_config_in_sandbox
+                        Defines whether Gutentags should |source| a project
+                        configuration file in |sandbox|.
+
+                        Defaults to `1`.
 
                                             *gutentags_define_advanced_commands*
 g:gutentags_define_advanced_commands

--- a/plugin/gutentags.vim
+++ b/plugin/gutentags.vim
@@ -103,10 +103,10 @@ augroup end
 " }}}
 
 " Toggles and Miscellaneous Commands {{{
-
 if g:gutentags_define_advanced_commands
     command! GutentagsToggleEnabled :let g:gutentags_enabled=!g:gutentags_enabled
     command! GutentagsToggleTrace   :call gutentags#toggletrace()
+    command! GutentagsRoot :call gutentags#root()
 endif
 
 if g:gutentags_debug

--- a/plugin/gutentags.vim
+++ b/plugin/gutentags.vim
@@ -41,8 +41,14 @@ let g:gutentags_init_user_func = get(g:, 'gutentags_init_user_func',
 let g:gutentags_add_ctrlp_root_markers = get(g:, 'gutentags_add_ctrlp_root_markers', 1)
 let g:gutentags_add_default_project_roots = get(g:, 'gutentags_add_default_project_roots', 1)
 let g:gutentags_project_root = get(g:, 'gutentags_project_root', [])
+let g:gutentags_project_config = get(g:, 'gutentags_project_config', '.gufig')
+let g:gutentags_project_config_in_sandbox = get(g:, 'gutentags_project_config_in_sandbox', 1)
 if g:gutentags_add_default_project_roots
     let g:gutentags_project_root += ['.git', '.hg', '.svn', '.bzr', '_darcs', '_FOSSIL_', '.fslckout']
+
+    if g:gutentags_project_config != ''
+        let g:gutentags_project_root += [g:gutentags_project_config]
+    endif
 endif
 
 let g:gutentags_project_root_finder = get(g:, 'gutentags_project_root_finder', '')


### PR DESCRIPTION
* feat: support gutentags_file_list_command on the gtags_cscope module

The original gutentags_file_list_command setting only works on ctags and cscope module, so to support the gtags_cscope module can be achieved through its -f option.

---

* feat: provide the GutentagsRoot command

Once Gutentags completed the locating of the project root, the user can change the directory to it via the GutentagsRoot command.

---

* feat: provide the g:gutentags_root_located_user_func hook

Once Gutentags complete the locating of the project root, it will call this user function (if present) to allow the user to load some custom configurations in the project root.

---

* feat: change the behavior of the g:gutentags_generate_on_new setting

In the original version, if the tag file does not exist and the g:gutentags_generate_on_missing is false, the g:gutentags_generate_on_new will control whether or not to generate a new tag. In general, this behavior is unpredictable for user who settings g:gutentags_generate_on_missing to False.

Therefore, let g:gutentags_generate_on_new setting only work when the tag file exists.