### PR TITLE
Re-create wildignore options file if missing

### DIFF
--- a/autoload/gutentags/ctags.vim
+++ b/autoload/gutentags/ctags.vim
@@ -252,9 +252,8 @@ function! s:generate_wildignore_options() abort
         if filereadable(s:wildignores_options_path)
             call gutentags#trace("Wildignore options file is up to date.")
             return
-        else
-            call gutentags#trace("Wildignore options file is not readable.")
         endif
+        call gutentags#trace("Wildignore options file is not readable.")
     endif
 
     if s:wildignores_options_path == ''

--- a/autoload/gutentags/ctags.vim
+++ b/autoload/gutentags/ctags.vim
@@ -247,9 +247,14 @@ endfunction
 
 function! s:generate_wildignore_options() abort
     if s:last_wildignores == &wildignore
-        " The 'wildignore' setting didn't change since last time we did this.
-        call gutentags#trace("Wildignore options file is up to date.")
-        return
+        " The 'wildignore' setting didn't change since last time we did this,
+        " but check if file still exist (could have been deleted if temp file)
+        if filereadable(s:wildignores_options_path)
+            call gutentags#trace("Wildignore options file is up to date.")
+            return
+        else
+            call gutentags#trace("Wildignore options file is not readable.")
+        endif
     endif
 
     if s:wildignores_options_path == ''


### PR DESCRIPTION
When the wildignore options file is a temp file it can be deleted by
other processes which clean up temp files, so check the file is readable
and re-create if necessary before adding it to the list of files from
which to read exclusion patterns (-x option for update_tags scripts).

Without this Gutentags sometimes gets stuck in a rut reporting ctags job
failed, probably because I use both GUI vim and terminal vim, but might
not use the GUI for days and when I return to it the temp file is gone.
