### PR TITLE
Improve gtags usage

### DIFF
--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -564,6 +564,7 @@ function! s:update_tags(bufno, module, write_mode, queue_mode) abort
                     \[l:proj_dir, l:tags_file,
                     \ {
                     \   'write_mode': a:write_mode,
+                    \   'file': expand('#'.a:bufno.':p'),
                     \ }])
     catch /^gutentags\:/
         echom "Error while generating ".a:module." file:"

--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -344,7 +344,7 @@ function! gutentags#setup_gutentags() abort
                 if g:gutentags_generate_on_missing && !filereadable(l:tagfile)
                     call gutentags#trace("Generating missing tags file: " . l:tagfile)
                     call s:update_tags(l:bn, module, 1, 1)
-                elseif g:gutentags_generate_on_new
+                elseif g:gutentags_generate_on_new && !filereadable(l:tagfile)
                     call gutentags#trace("Generating tags file: " . l:tagfile)
                     call s:update_tags(l:bn, module, 1, 1)
                 endif

--- a/autoload/gutentags/gtags_cscope.vim
+++ b/autoload/gutentags/gtags_cscope.vim
@@ -82,6 +82,8 @@ function! gutentags#gtags_cscope#init(project_root) abort
 endfunction
 
 function! gutentags#gtags_cscope#generate(proj_dir, tags_file, gen_opts) abort
+    let l:write_mode = a:gen_opts['write_mode']
+
     let l:cmd = [s:runner_exe]
     let l:cmd += ['-e', '"' . g:gutentags_gtags_executable . '"']
 
@@ -103,6 +105,9 @@ function! gutentags#gtags_cscope#generate(proj_dir, tags_file, gen_opts) abort
 
     if g:gutentags_gtags_skip_symlink != ''
         let l:cmd += ['--skip-symlink='.g:gutentags_gtags_skip_symlink]
+    endif
+    if l:write_mode == 0 && has_key(a:gen_opts, 'file')
+        let l:cmd += ['--single-update', '"'.a:gen_opts['file'].'"']
     endif
     let l:cmd = gutentags#make_args(l:cmd)
 

--- a/autoload/gutentags/gtags_cscope.vim
+++ b/autoload/gutentags/gtags_cscope.vim
@@ -23,6 +23,10 @@ if !exists('g:gutentags_gtags_cscope_executable')
     let g:gutentags_gtags_cscope_executable = 'gtags-cscope'
 endif
 
+if !exists('g:gutentags_gtags_skip_symlink')
+    let g:gutentags_gtags_skip_symlink = 'a'
+endif
+
 if !exists('g:gutentags_auto_add_gtags_cscope')
     let g:gutentags_auto_add_gtags_cscope = 1
 endif
@@ -97,6 +101,9 @@ function! gutentags#gtags_cscope#generate(proj_dir, tags_file, gen_opts) abort
     let l:db_path = fnamemodify(a:tags_file, ':p:h')
     let l:cmd += ['--incremental', '"'.l:db_path.'"']
 
+    if g:gutentags_gtags_skip_symlink != ''
+        let l:cmd += ['--skip-symlink='.g:gutentags_gtags_skip_symlink]
+    endif
     let l:cmd = gutentags#make_args(l:cmd)
 
     call gutentags#trace("Running: " . string(l:cmd))

--- a/doc/gutentags.txt
+++ b/doc/gutentags.txt
@@ -694,6 +694,15 @@ g:gutentags_gtags_cscope_executable
                         executable to use to generate the code database.
                         Defaults to `"gtags-cscope"`.
 
+	                                        *gutentags_gtags_skip_symlink*
+g:gutentags_gtags_skip_symlink
+			When set to `""`, Gutentags will remove --skip-symlink
+			flag in gtags generation command, options:
+			- 'a' then skip all symbolic links
+			- 'f' then skip only symbolic links for file
+			- 'd' then skip only symbolic links for directory.
+                        Defaults to `"a"`.
+
                                                 *gutentags_gtags_dbpath*
 g:gutentags_gtags_dbpath
                         Path from the cache directory (|gutentags_cache_dir|


### PR DESCRIPTION
I found this plugin is really useful, but my computer get slower every time when the tag is updating. Just a few modifications, it pretty much solved my issue. 

Here is what has been modified:
- Only generate new tag file if the current one is unreadable
- Add `--skip-symlink` to an optional configuration
- If specified file is provided, gtags can use `--single-update` argument to reduce tag updating time

I will be happy if these changes can be merged.