### PR TITLE
Include override warning in docs for `.gutctags`

### DIFF
--- a/doc/gutentags.txt
+++ b/doc/gutentags.txt
@@ -730,7 +730,10 @@ following files present in the project root directory:
                                                 *gutentags-.gutctags*
 `.gutctags`: if this file exists, Ctags will be told to load additional
 command-line parameters by reading it line by line (see the Ctags
-documentation for more information).
+documentation for more information). This will override the default options
+file, which adds `--recurse=yes`, so unless you are using
+|gutentags_file_list_command| you will want to include `--recurse=yes` in your
+`.gutctags` file.
 
 Note that for complex reasons, Gutentags can't run `ctags` from the project
 root if you're using |gutentags_cache_dir|, so if the `.gutctags` file exists,


### PR DESCRIPTION
I tried using `.gutctags` but found that my tags file was always coming out empty. I eventually found that this was because ctags wasn't being told to recurse, and a bit more debugging showed that `.gutctags`, if present, overrides the default `ctags_recursive.options` file. I've added a warning to that effect to the docs.