### PR TITLE
Use ripgrep (rg) instead of grep where available

### DIFF
--- a/plat/unix/update_tags.sh
+++ b/plat/unix/update_tags.sh
@@ -99,7 +99,12 @@ if [ -f "$TAGS_FILE" ]; then
     if [ "$UPDATED_SOURCE" != "" ]; then
         echo "Removing references to: $UPDATED_SOURCE"
         tab="	"
-        cmd="grep --text -Ev '^[^$tab]+$tab$UPDATED_SOURCE$tab' '$TAGS_FILE' > '$TAGS_FILE.temp'"
+        # use ripgrep if available
+        if which rg; then
+            cmd="rg --text -ev '^[^$tab]+$tab$UPDATED_SOURCE$tab' '$TAGS_FILE' > '$TAGS_FILE.temp'"
+        else 
+            cmd="grep --text -Ev '^[^$tab]+$tab$UPDATED_SOURCE$tab' '$TAGS_FILE' > '$TAGS_FILE.temp'"
+        fi
         echo "$cmd"
         eval "$cmd" || true
         INDEX_WHOLE_PROJECT=0

--- a/plat/unix/update_tags.sh
+++ b/plat/unix/update_tags.sh
@@ -101,7 +101,7 @@ if [ -f "$TAGS_FILE" ]; then
         tab="	"
         # use ripgrep if available
         if command -v rg > /dev/null 2>&1; then
-            GREP_CMD="rg --noconfig"
+            GREP_CMD="rg --no-config"
         else 
             GREP_CMD="grep -E"
         fi

--- a/plat/unix/update_tags.sh
+++ b/plat/unix/update_tags.sh
@@ -100,11 +100,12 @@ if [ -f "$TAGS_FILE" ]; then
         echo "Removing references to: $UPDATED_SOURCE"
         tab="	"
         # use ripgrep if available
-        if which rg; then
-            cmd="rg --text -ev '^[^$tab]+$tab$UPDATED_SOURCE$tab' '$TAGS_FILE' > '$TAGS_FILE.temp'"
+        if command -v rg > /dev/null 2>&1; then
+            GREP_CMD="rg --noconfig"
         else 
-            cmd="grep --text -Ev '^[^$tab]+$tab$UPDATED_SOURCE$tab' '$TAGS_FILE' > '$TAGS_FILE.temp'"
+            GREP_CMD="grep -E"
         fi
+        cmd="${GREP_CMD} --text -v '^[^$tab]+$tab$UPDATED_SOURCE$tab' '$TAGS_FILE' > '$TAGS_FILE.temp'"
         echo "$cmd"
         eval "$cmd" || true
         INDEX_WHOLE_PROJECT=0


### PR DESCRIPTION
[Ripgrep](https://github.com/BurntSushi/ripgrep) is orders of magnitude faster than grep especially on big files. 

Here is a sample from my workspace. My tags file for entire project hovers around 16G

du -sh tags
7.3G    tags

time rg --text -ve ^[^?]+?my_project_foo.cpp? tags > tgs.tmp1                                                                                                                                                                                                           
real 48.223     user 7.852      sys 38.735      pcpu 96.60  

time grep --text -Ev ^[^?]+?my_project_foo.cpp? tags > tgs.tmp  
real 106.256    user 13.446     sys 88.974      pcpu 96.39   

