### PR TITLE
Add setting b:gutentags_ctags_extra_args

### DIFF
--- a/autoload/gutentags/ctags.vim
+++ b/autoload/gutentags/ctags.vim
@@ -9,7 +9,6 @@ let g:gutentags_ctags_auto_set_tags = get(g:, 'gutentags_ctags_auto_set_tags', 1
 let g:gutentags_ctags_options_file = get(g:, 'gutentags_ctags_options_file', '.gutctags')
 let g:gutentags_ctags_check_tagfile = get(g:, 'gutentags_ctags_check_tagfile', 0)
 let g:gutentags_ctags_extra_args = get(g:, 'gutentags_ctags_extra_args', [])
-let b:gutentags_ctags_extra_args = getbufvar("", "gutentags_ctags_extra_args", [])
 let g:gutentags_ctags_post_process_cmd = get(g:, 'gutentags_ctags_post_process_cmd', '')
 
 let g:gutentags_ctags_exclude = get(g:, 'gutentags_ctags_exclude', [])
@@ -173,7 +172,7 @@ function! gutentags#ctags#generate(proj_dir, tags_file, gen_opts) abort
     if l:use_tag_relative_opt
         let l:cmd += ['-O', shellescape("--tag-relative=yes")]
     endif
-    for extra_arg in g:gutentags_ctags_extra_args + b:gutentags_ctags_extra_args
+    for extra_arg in g:gutentags_ctags_extra_args + getbufvar("", "gutentags_ctags_extra_args", [])
         let l:cmd += ['-O', shellescape(extra_arg)]
     endfor
     if !empty(g:gutentags_ctags_post_process_cmd)

--- a/autoload/gutentags/ctags.vim
+++ b/autoload/gutentags/ctags.vim
@@ -9,7 +9,7 @@ let g:gutentags_ctags_auto_set_tags = get(g:, 'gutentags_ctags_auto_set_tags', 1
 let g:gutentags_ctags_options_file = get(g:, 'gutentags_ctags_options_file', '.gutctags')
 let g:gutentags_ctags_check_tagfile = get(g:, 'gutentags_ctags_check_tagfile', 0)
 let g:gutentags_ctags_extra_args = get(g:, 'gutentags_ctags_extra_args', [])
-let b:gutentags_ctags_extra_args = get(b:, 'gutentags_ctags_extra_args', [])
+let b:gutentags_ctags_extra_args = getbufvar("", "gutentags_ctags_extra_args", [])
 let g:gutentags_ctags_post_process_cmd = get(g:, 'gutentags_ctags_post_process_cmd', '')
 
 let g:gutentags_ctags_exclude = get(g:, 'gutentags_ctags_exclude', [])

--- a/autoload/gutentags/ctags.vim
+++ b/autoload/gutentags/ctags.vim
@@ -9,6 +9,7 @@ let g:gutentags_ctags_auto_set_tags = get(g:, 'gutentags_ctags_auto_set_tags', 1
 let g:gutentags_ctags_options_file = get(g:, 'gutentags_ctags_options_file', '.gutctags')
 let g:gutentags_ctags_check_tagfile = get(g:, 'gutentags_ctags_check_tagfile', 0)
 let g:gutentags_ctags_extra_args = get(g:, 'gutentags_ctags_extra_args', [])
+let b:gutentags_ctags_extra_args = get(b:, 'gutentags_ctags_extra_args', [])
 let g:gutentags_ctags_post_process_cmd = get(g:, 'gutentags_ctags_post_process_cmd', '')
 
 let g:gutentags_ctags_exclude = get(g:, 'gutentags_ctags_exclude', [])
@@ -172,7 +173,7 @@ function! gutentags#ctags#generate(proj_dir, tags_file, gen_opts) abort
     if l:use_tag_relative_opt
         let l:cmd += ['-O', shellescape("--tag-relative=yes")]
     endif
-    for extra_arg in g:gutentags_ctags_extra_args
+    for extra_arg in g:gutentags_ctags_extra_args + b:gutentags_ctags_extra_args
         let l:cmd += ['-O', shellescape(extra_arg)]
     endfor
     if !empty(g:gutentags_ctags_post_process_cmd)

--- a/doc/gutentags.txt
+++ b/doc/gutentags.txt
@@ -622,6 +622,11 @@ g:gutentags_ctags_extra_args
                         A list of arguments to pass to `ctags`.
                         Defaults to `[]`.
 
+b:gutentags_ctags_extra_args
+                        Like g:gutentags_ctags_extra_args but only valid for
+                        the current buffer.
+                        Defaults to `[]`.
+
                                                 *gutentags_ctags_post_process_cmd*
 g:gutentags_ctags_post_process_cmd
                         If defined, the tags generation script will run the


### PR DESCRIPTION
The new buffer-local settings `b:gutentags_ctags_extra_args` can be used to create separate tag files for different programming languages.

Example:

```vim
autocmd FileType python let b:gutentags_ctags_extra_args = ['--languages=Python', '-o', 'tags-' . &ft] | execute 'setl tags=tags-' . &ft
autocmd FileType cpp    let b:gutentags_ctags_extra_args = ['--languages=C++', '-o', 'tags-' . &ft]    | execute 'setl tags=tags-' . &ft
autocmd FileType vim    let b:gutentags_ctags_extra_args = ['--languages=Vim', '-o', 'tags-' . &ft]    | execute 'setl tags=tags-' . &ft
autocmd FileType sh     let b:gutentags_ctags_extra_args = ['--languages=Sh', '-o', 'tags-' . &ft]     | execute 'setl tags=tags-' . &ft
autocmd FileType c      let b:gutentags_ctags_extra_args = ['-h=.c.h', '-o', 'tags-' . &ft]            | execute 'setl tags=tags-' . &ft
```

Updated example configuration as suggested by @ludovicchabant:

```vim
autocmd FileType python let b:gutentags_ctags_extra_args = ['--languages=Python'] | let b:gutentags_ctags_tagfile = "tags-" . &ft
autocmd FileType cpp    let b:gutentags_ctags_extra_args = ['--languages=C++']    | let b:gutentags_ctags_tagfile = "tags-" . &ft
autocmd FileType vim    let b:gutentags_ctags_extra_args = ['--languages=Vim']    | let b:gutentags_ctags_tagfile = "tags-" . &ft
autocmd FileType sh     let b:gutentags_ctags_extra_args = ['--languages=Sh']     | let b:gutentags_ctags_tagfile = "tags-" . &ft
autocmd FileType c      let b:gutentags_ctags_extra_args = ['-h=.c.h']            | let b:gutentags_ctags_tagfile = "tags-" . &ft
```


Fixes #264!?