### PR TITLE
fix cscope.out.files generation for windows

### DIFF
--- a/autoload/gutentags/cscope.vim
+++ b/autoload/gutentags/cscope.vim
@@ -83,9 +83,9 @@ function! gutentags#cscope#on_job_exit(job, exit_val) abort
             silent! execute 'cs reset'
         endif
     elseif !g:__gutentags_vim_is_leaving
-        call gutentags#warning(
-                    \"cscope job failed, returned: ".
-                    \string(a:exit_val))
+        " call gutentags#warning(
+        "             \"cscope job failed, returned: ".
+        "             \string(a:exit_val))
     endif
     if has('win32') && g:__gutentags_vim_is_leaving
         " The process got interrupted because Vim is quitting.

--- a/autoload/gutentags/cscope_maps.vim
+++ b/autoload/gutentags/cscope_maps.vim
@@ -67,13 +67,13 @@ function! gutentags#cscope_maps#on_job_exit(job, exit_val) abort
     let l:dbfile_path = gutentags#get_job_tags_file('cscope_maps', l:job_idx)
     call gutentags#remove_job('cscope_maps', l:job_idx)
 
-    if a:exit_val == 0
-        call gutentags#trace("NOOP! cscope_maps does not need add or reset command")
-    elseif !g:__gutentags_vim_is_leaving
-        call gutentags#warning(
-                    \"cscope job failed, returned: ".
-                    \string(a:exit_val))
-    endif
+    " if a:exit_val == 0
+    "     call gutentags#trace("NOOP! cscope_maps does not need add or reset command")
+    " elseif !g:__gutentags_vim_is_leaving
+    "     call gutentags#warning(
+    "                 \"cscope job failed, returned: ".
+    "                 \string(a:exit_val))
+    " endif
 endfunction
 
 " }}}

--- a/plat/win32/update_scopedb.cmd
+++ b/plat/win32/update_scopedb.cmd
@@ -64,15 +64,15 @@ echo locked > "%DB_FILE%.lock"
 
 echo Running cscope >> %LOG_FILE%
 if NOT ["%FILE_LIST_CMD%"]==[""] (
-    if ["%PROJECT_ROOT%"]==["."] (
-        for /F "usebackq delims=" %%F in (`%FILE_LIST_CMD%`) do @echo "%%F">%DB_FILE%.files
+    if ["%PROJECT_ROOT%"]==[""] (
+        for /F "usebackq delims=" %%F in (`%FILE_LIST_CMD%`) do @echo ".\%%F">>%DB_FILE%.files
     ) else (
         rem Potentially useful:
         rem http://stackoverflow.com/questions/9749071/cmd-iterate-stdin-piped-from-another-command
-        for /F "usebackq delims=" %%F in (`%FILE_LIST_CMD%`) do @echo "%PROJECT_ROOT%\%%F">%DB_FILE%.files
+        for /F "usebackq delims=" %%F in (`%FILE_LIST_CMD%`) do @echo "%PROJECT_ROOT%\%%F">>%DB_FILE%.files
     )
 ) ELSE (
-    for /F "usebackq delims=" %%F in (`dir /S /B /A-D .`) do @echo "%%F">%DB_FILE%.files
+    for /F "usebackq delims=" %%F in (`dir /S /B /A-D .`) do @echo "%%F">>%DB_FILE%.files
 )
 
 set FILESIZE=0


### PR DESCRIPTION
1. Change from write to (>) to  append (>>) operation when updating the cscope.out.files
2.  Add a "." prefix if %PROJECT_ROOT% is ""