### PR TITLE
Add new flag to always generate tags as absolute.

### DIFF
--- a/doc/gutentags.txt
+++ b/doc/gutentags.txt
@@ -396,6 +396,12 @@ g:gutentags_project_root_finder
                         behaviour by calling
                         `gutentags#default_get_project_root`.
 
+                                                *gutentags_always_absolute*
+g:gutentags_always_absolute
+                        Always resolve tags file as absolute, even if tags
+                        file is local.
+                        Defaults to 0.
+
                                                 *gutentags_generate_on_missing*
 g:gutentags_generate_on_missing
                         If set to 1, Gutentags will start generating an initial

--- a/plugin/gutentags.vim
+++ b/plugin/gutentags.vim
@@ -46,6 +46,7 @@ if g:gutentags_add_default_project_roots
 endif
 
 let g:gutentags_project_root_finder = get(g:, 'gutentags_project_root_finder', '')
+let g:gutentags_always_absolute = get(g:, 'gutentags_always_absolute', 0)
 
 let g:gutentags_project_info = get(g:, 'gutentags_project_info', [])
 call add(g:gutentags_project_info, {'type': 'python', 'file': 'setup.py'})


### PR DESCRIPTION
Disables the detection of tags_file_is_local.
Adds an additional way of fixing https://github.com/ludovicchabant/vim-gutentags/issues/70 , by forcing only absolute paths.