### PR TITLE
Add locking and traps for gtags_update.sh, and really do locking

### DIFF
--- a/plat/unix/update_gtags.sh
+++ b/plat/unix/update_gtags.sh
@@ -33,7 +33,7 @@ while [[ $# -ne 0 ]]; do
       shift 2
       ;;
     *)
-      GTAGS_ARGS="$GTAGS_ARGS $1"
+      GTAGS_ARGS="$GTAGS_ARGS $(printf %q "$1")"
       shift
       ;;
   esac

--- a/plat/unix/update_gtags.sh
+++ b/plat/unix/update_gtags.sh
@@ -53,10 +53,10 @@ echo $$ > "$LOCKFILE"
 trap '\
 errorcode=$?; \
 for f in $TAGS_FILES; \
-do f="$GTAGS_PATHARG/$f"; test -s "$f" && continue || rm -f "$f"; done; \
+do rm -f "$GTAGS_PATHARG/$f"; done; \
 rm -f "$LOCKFILE"; \
 exit $errorcode; \
-' INT QUIT TERM EXIT
+' INT QUIT TERM
 
 echo "Running gtags:"
 echo "$CMD"

--- a/plat/unix/update_gtags.sh
+++ b/plat/unix/update_gtags.sh
@@ -2,10 +2,12 @@
 
 set -e
 
-LOCKFILE=gtags.lock
 PROG_NAME=$0
 GTAGS_EXE=gtags
 FILE_LIST_CMD=
+TAGS_FILES="GTAGS GPATH GRTAGS"
+GTAGS_PATHARG="${!#}" # last arg is always the path
+LOCKFILE="$GTAGS_PATHARG/gtags.lock"
 
 ShowUsage() {
     echo "Usage:"
@@ -45,6 +47,15 @@ fi
 
 echo "Locking gtags files..."
 echo $$ > "$LOCKFILE"
+
+# Remove lock and any partial files on script exit
+trap '\
+errorcode=$?; \
+for f in $TAGS_FILES; \
+do f="$GTAGS_PATHARG/$f"; test -s "$f" && continue || rm -f "$f"; done; \
+rm -f "$LOCKFILE"; \
+exit $errorcode; \
+' INT QUIT TERM EXIT
 
 echo "Running gtags:"
 echo "$CMD"

--- a/plat/unix/update_gtags.sh
+++ b/plat/unix/update_gtags.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+LOCKFILE=gtags.lock
 PROG_NAME=$0
 GTAGS_EXE=gtags
 FILE_LIST_CMD=
@@ -42,7 +43,14 @@ else
   CMD="$GTAGS_EXE $GTAGS_ARGS"
 fi
 
+echo "Locking gtags files..."
+echo $$ > "$LOCKFILE"
+
 echo "Running gtags:"
 echo "$CMD"
 eval "$CMD"
+
+echo "Unlocking gtags file..."
+rm -f "$LOCKFILE"
+
 echo "Done."

--- a/plat/unix/update_gtags.sh
+++ b/plat/unix/update_gtags.sh
@@ -46,6 +46,7 @@ else
 fi
 
 echo "Locking gtags files..."
+set -C
 echo $$ > "$LOCKFILE"
 
 # Remove lock and any partial files on script exit

--- a/plat/unix/update_pyscopedb.sh
+++ b/plat/unix/update_pyscopedb.sh
@@ -51,6 +51,7 @@ if [ "$1" != "" ]; then
 fi
 
 echo "Locking pycscope DB file..."
+set -C
 echo $$ > "$DB_FILE.lock"
 
 # Remove lock and temp file if script is stopped unexpectedly.

--- a/plat/unix/update_scopedb.sh
+++ b/plat/unix/update_scopedb.sh
@@ -54,10 +54,6 @@ if [ "$1" != "" ]; then
     exit 1
 fi
 
-echo "Locking cscope DB file..."
-set -C
-echo $$ > "$DB_FILE.lock"
-
 # Remove lock and temp file if script is stopped unexpectedly.
 CleanUp() {
     rm -f "$DB_FILE.lock" "$DB_FILE.files" "$DB_FILE.temp"
@@ -65,6 +61,10 @@ CleanUp() {
         rm -f "$DB_FILE.temp.in" "$DB_FILE.temp.po"
     fi
 }
+
+echo "Locking cscope DB file..."
+set -C
+echo $$ > "$DB_FILE.lock"
 
 trap CleanUp INT QUIT TERM EXIT
 

--- a/plat/unix/update_scopedb.sh
+++ b/plat/unix/update_scopedb.sh
@@ -55,6 +55,7 @@ if [ "$1" != "" ]; then
 fi
 
 echo "Locking cscope DB file..."
+set -C
 echo $$ > "$DB_FILE.lock"
 
 # Remove lock and temp file if script is stopped unexpectedly.

--- a/plat/unix/update_tags.sh
+++ b/plat/unix/update_tags.sh
@@ -89,6 +89,7 @@ if [ "$1" != "" ]; then
 fi
 
 echo "Locking tags file..."
+set -C
 echo $$ > "$TAGS_FILE.lock"
 
 # Remove lock and temp file if script is stopped unexpectedly.


### PR DESCRIPTION
`gtags-cscope` currently has no update script trap, like ctags and cscope have, which does a partial-file cleanup on [premature] exit.  if any zero-byte gtags files exist, they will be treated as a prior run by forthcoming gtags, which will be confused that the file is apparently corrupted.

The attached add a trap and do cleanup in `gtags`, like `ctags`.

Also, there was no locking in `gtags`, so this patch adds naive locking, same as the other scripts (ie `ctags`) have already.

Locking was also fixed in all the update scripts.  There was a bug that existence of a lockfile was ignored.  The noclobber option needs to be set in the shell, in order for 'set -e' to force an exit if the file exists already on redirect.  There is a patch included to fix this.  While it should be fixed, it may result in more user reports of apparent update script failure, since locking did not work before, and simultaneous attempt was never noticed.

It might be better to ignore some sources of error and exit 0 anyways so the simultaneous access is not a reported issue.  But if we did this, it could hide a previous aborted attempt leaving files, and then never be able to start again.  Some warning might be in order.

The changes should work both with and without `g:gutentags_cache_dir`.  In this patch, the lock files are kept alongside the tags files.  The other option would have been to put them in the scanned directory.

Fixes #319