### PR TITLE
docs: gutentags_add_default_project add default value

### DIFF
--- a/doc/gutentags.txt
+++ b/doc/gutentags.txt
@@ -348,6 +348,7 @@ g:gutentags_add_default_project_roots
                         when Gutentags searches for a project root.
                         The default markers are:
                         `['.git', '.hg', '.svn', '.bzr', '_darcs', '_darcs', '_FOSSIL_', '.fslckout']`
+                        Defaults to 1.
 
                                             *gutentags_add_ctrlp_root_markers*
 g:gutentags_add_ctrlp_root_markers


### PR DESCRIPTION
Looking over docs it seemed out of place to me that this default value was left out.

Correct if mistaken.